### PR TITLE
Add MEXC as a Provider Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This is a standalone version of [Umee's fantastic work](https://github.com/umee-
 The list of current supported providers:
 
 - [Binance](https://www.binance.com/en)
+- [MEXC](https://www.mexc.com/)
 - [Coinbase](https://www.coinbase.com/)
 - [Gate](https://www.gate.io/)
 - [Huobi](https://www.huobi.com/en-us/)

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ const (
 
 	ProviderKraken   = "kraken"
 	ProviderBinance  = "binance"
+	ProviderMexc     = "mexc"
 	ProviderOsmosis  = "osmosis"
 	ProviderHuobi    = "huobi"
 	ProviderOkx      = "okx"
@@ -41,6 +42,7 @@ var (
 	SupportedProviders = map[string]struct{}{
 		ProviderKraken:   {},
 		ProviderBinance:  {},
+		ProviderMexc:     {},
 		ProviderOsmosis:  {},
 		ProviderOkx:      {},
 		ProviderHuobi:    {},

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -450,6 +450,9 @@ func NewProvider(
 	case config.ProviderKraken:
 		return provider.NewKrakenProvider(ctx, logger, endpoint, providerPairs...)
 
+	case config.ProviderMexc:
+		return provider.NewMexcProvider(ctx, logger, endpoint, providerPairs...)
+
 	case config.ProviderOsmosis:
 		return provider.NewOsmosisProvider(endpoint), nil
 

--- a/oracle/provider/mexc.go
+++ b/oracle/provider/mexc.go
@@ -151,7 +151,7 @@ func (p *MexcProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]
 	tickerPrices := make(map[string]TickerPrice, len(pairs))
 
 	for _, cp := range pairs {
-		key := currencyPairToMexcPair(cp)
+		key := cp.String()
 		price, err := p.getTickerPrice(key)
 		if err != nil {
 			return nil, err
@@ -276,14 +276,14 @@ func (p *MexcProvider) messageReceived(messageType int, bz []byte) {
 	)
 
 	tickerErr = json.Unmarshal(bz, &tickerResp)
-	subscribed_pairs := make([]string, 0, len(p.subscribedPairs))
+	// subscribed_pairs := make([]string, 0, len(p.subscribedPairs))
 	for _, cp := range p.subscribedPairs {
-		subscribed_pairs = append(subscribed_pairs, currencyPairToMexcPair(cp))
-	}
+		// 	subscribed_pairs = append(subscribed_pairs, currencyPairToMexcPair(cp))
+		// }
 
-	for i := range subscribed_pairs {
-		if tickerResp.Symbol[subscribed_pairs[i]].LastPrice != 0 {
-			p.setTickerPair(subscribed_pairs[i], tickerResp.Symbol[subscribed_pairs[i]])
+		// for i := range subscribed_pairs {
+		if tickerResp.Symbol[currencyPairToMexcPair(cp)].LastPrice != 0 {
+			p.setTickerPair(cp.String(), tickerResp.Symbol[currencyPairToMexcPair(cp)])
 			telemetry.IncrCounter(
 				1,
 				"websocket",

--- a/oracle/provider/mexc.go
+++ b/oracle/provider/mexc.go
@@ -478,7 +478,7 @@ func (p *MexcProvider) GetAvailablePairs() (map[string]struct{}, error) {
 // currencyPairToMexcPair receives a currency pair and return mexc
 // ticker symbol atomusdt@ticker.
 func currencyPairToMexcPair(cp types.CurrencyPair) string {
-	return strings.ToLower(cp.Base + "_" + cp.Quote)
+	return strings.ToUpper(cp.Base + "_" + cp.Quote)
 }
 
 // newMexcCandleSubscriptionMsg returns a new candle subscription Msg.

--- a/oracle/provider/mexc.go
+++ b/oracle/provider/mexc.go
@@ -78,9 +78,9 @@ type (
 
 	// MexcCandle candle Mexc websocket channel "kline_1m" response.
 	MexcCandle struct {
-		Channel  string             `json:"channel"` // expect "push.kline"
-		Symbol   string             `json:"symbol"`  // Symbol ex.: ATOM_USDT
-		Metadata MexcCandleMetadata `json:"data"`    // Metadata for candle
+		//Channel  string             `json:"channel"` // expect "push.kline"
+		Symbol   string             `json:"symbol"` // Symbol ex.: ATOM_USDT
+		Metadata MexcCandleMetadata `json:"data"`   // Metadata for candle
 	}
 
 	// MexcSubscribeMsg Msg to subscribe all the tickers channels.

--- a/oracle/provider/mexc.go
+++ b/oracle/provider/mexc.go
@@ -1,0 +1,503 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"price-feeder/config"
+	"price-feeder/oracle/types"
+
+	"github.com/cosmos/cosmos-sdk/telemetry"
+	"github.com/gorilla/websocket"
+	"github.com/rs/zerolog"
+)
+
+const (
+	mexcWSHost   = "wbs.mexc.com"
+	mexcWSPath   = "/raw/ws"
+	mexcRestHost = "https://www.mexc.com/"
+	mexcRestPath = "/open/api/v2/market/ticker"
+	// mexcTicker   = "ticker"
+	// mexcCandle   = "kline"
+	// mexcCoins    = "coin/list"
+	// mexcSymbols  = "symbols"
+)
+
+var _ Provider = (*MexcProvider)(nil)
+
+type (
+	// MexcProvider defines an Oracle provider implemented by the Mexc public
+	// API.
+	//
+	// REF: https://binance-docs.github.io/apidocs/spot/en/#individual-symbol-mini-ticker-stream
+	// REF: https://binance-docs.github.io/apidocs/spot/en/#kline-candlestick-streams
+	MexcProvider struct {
+		wsURL           url.URL
+		wsClient        *websocket.Conn
+		logger          zerolog.Logger
+		mtx             sync.RWMutex
+		endpoints       config.ProviderEndpoint
+		tickers         map[string]MexcTicker      // Symbol => MexcTicker
+		candles         map[string][]MexcCandle    // Symbol => MexcCandle
+		subscribedPairs map[string]types.CurrencyPair // Symbol => types.CurrencyPair
+	}
+
+	// MexcTicker ticker price response. https://pkg.go.dev/encoding/json#Unmarshal
+	// Unmarshal matches incoming object keys to the keys used by Marshal (either the
+	// struct field name or its tag), preferring an exact match but also accepting a
+	// case-insensitive match. C field which is Statistics close time is not used, but
+	// it avoids to implement specific UnmarshalJSON.
+	MexcTicker struct {
+		Symbol    string `json:"symbol"` // Symbol ex.: ATOM_USDT
+		LastPrice string `json:"last"` // Last price ex.: 0.0025
+		Volume    string `json:"volume"` // Total traded base asset volume ex.: 1000
+		C         uint64 `json:"C"` // Statistics close time
+	}
+
+	// MexcCandleMetadata candle metadata used to compute tvwap price.
+	MexcCandleMetadata struct {
+		Close     string `json:"c"` // Price at close
+		TimeStamp int64  `json:"t"` // Close time in unix epoch ex.: 1645756200000
+		Volume    string `json:"v"` // Volume during period
+	}
+
+	// MexcCandle candle Mexc websocket channel "kline_1m" response.
+	MexcCandle struct {
+		Symbol   string             `json:"symbol"` // Symbol ex.: BTCUSDT
+		Metadata MexcCandleMetadata `json:"data"` // Metadata for candle
+	}
+
+	// MexcSubscribeMsg Msg to subscribe all the tickers channels.
+	MexcSubscriptionMsg struct {
+		Method string   `json:"op"` // SUBSCRIBE/UNSUBSCRIBE
+		Params []string `json:"symbol"` // streams to subscribe ex.: usdtatom@ticker
+		ID     uint16   `json:"channel"`     // identify messages going back and forth
+	}
+
+	// MexcSubscribeMsg Msg to subscribe all the tickers channels.
+	MexcCandleSubscriptionMsg struct {
+		OP       string  `json:"op"` // kline
+		Symbol   string  `json:"symbol"` // streams to subscribe ex.: usdtatom@ticker
+		Interval string  `json:"interval"` // Min1、Min5、Min15、Min30
+	}
+
+	// MexcSubscribeMsg Msg to subscribe all the tickers channels.
+	MexcTickerSubscriptionMsg struct {
+		OP string       `json:"op"` // kline
+	}
+
+	// MexcPairSummary defines the response structure for a Mexc pair
+	// summary.
+	MexcPairSummary struct {
+		Symbol string `json:"symbol"`
+	}
+)
+
+func NewMexcProvider(
+	ctx context.Context,
+	logger zerolog.Logger,
+	endpoints config.ProviderEndpoint,
+	pairs ...types.CurrencyPair,
+) (*MexcProvider, error) {
+	if (endpoints.Name) != config.ProviderMexc {
+		endpoints = config.ProviderEndpoint{
+			Name:      config.ProviderMexc,
+			Rest:      mexcRestHost,
+			Websocket: mexcWSHost,
+		}
+	}
+
+	wsURL := url.URL{
+		Scheme: "wss",
+		Host:   endpoints.Websocket,
+		Path:   mexcWSPath,
+	}
+
+	wsConn, _, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error connecting to mexc websocket: %w", err)
+	}
+
+	provider := &MexcProvider{
+		wsURL:           wsURL,
+		wsClient:        wsConn,
+		logger:          logger.With().Str("provider", "mexc").Logger(),
+		endpoints:       endpoints,
+		tickers:         map[string]MexcTicker{},
+		candles:         map[string][]MexcCandle{},
+		subscribedPairs: map[string]types.CurrencyPair{},
+	}
+
+	if err := provider.SubscribeCurrencyPairs(pairs...); err != nil {
+		return nil, err
+	}
+
+	go provider.handleWebSocketMsgs(ctx)
+
+	return provider, nil
+}
+
+// GetTickerPrices returns the tickerPrices based on the provided pairs.
+func (p *MexcProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]TickerPrice, error) {
+	tickerPrices := make(map[string]TickerPrice, len(pairs))
+
+	for _, cp := range pairs {
+		key := cp.String()
+		price, err := p.getTickerPrice(key)
+		if err != nil {
+			return nil, err
+		}
+		tickerPrices[key] = price
+	}
+
+	return tickerPrices, nil
+}
+
+// GetCandlePrices returns the candlePrices based on the provided pairs.
+func (p *MexcProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]CandlePrice, error) {
+	candlePrices := make(map[string][]CandlePrice, len(pairs))
+
+	for _, cp := range pairs {
+		key := cp.String()
+		prices, err := p.getCandlePrices(key)
+		if err != nil {
+			return nil, err
+		}
+		candlePrices[key] = prices
+	}
+
+	return candlePrices, nil
+}
+
+// SubscribeCurrencyPairs subscribe all currency pairs into ticker and candle channels.
+func (p *MexcProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
+	if len(cps) == 0 {
+		return fmt.Errorf("currency pairs is empty")
+	}
+
+	if err := p.subscribeChannels(cps...); err != nil {
+		return err
+	}
+
+	p.setSubscribedPairs(cps...)
+	return nil
+}
+
+// subscribeChannels subscribe to the ticker and candle channels for all currency pairs.
+func (p *MexcProvider) subscribeChannels(cps ...types.CurrencyPair) error {
+	if err := p.subscribeTickers(cps...); err != nil {
+		return err
+	}
+
+	return p.subscribeCandles(cps...)
+}
+
+// subscribeTickers subscribe to the ticker channel for all currency pairs.
+func (p *MexcProvider) subscribeTickers(cps ...types.CurrencyPair) error {
+	pairs := make([]string, len(cps))
+
+	for i, cp := range cps {
+		pairs[i] = currencyPairToMexcPair(cp)
+	}
+
+	return p.subscribePairs(pairs...)
+}
+
+// subscribeCandles subscribe to the candle channel for all currency pairs.
+func (p *MexcProvider) subscribeCandles(cps ...types.CurrencyPair) error {
+	pairs := make([]string, len(cps))
+
+	for i, cp := range cps {
+		pairs[i] = currencyPairToMexcPair(cp)
+	}
+
+	return p.subscribePairs(pairs...)
+}
+
+// subscribedPairsToSlice returns the map of subscribed pairs as a slice.
+func (p *MexcProvider) subscribedPairsToSlice() []types.CurrencyPair {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	return types.MapPairsToSlice(p.subscribedPairs)
+}
+
+func (p *MexcProvider) getTickerPrice(key string) (TickerPrice, error) {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	ticker, ok := p.tickers[key]
+	if !ok {
+		return TickerPrice{}, fmt.Errorf("mexc provider failed to get ticker price for %s", key)
+	}
+
+	return ticker.toTickerPrice()
+}
+
+func (p *MexcProvider) getCandlePrices(key string) ([]CandlePrice, error) {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	candles, ok := p.candles[key]
+	if !ok {
+		return []CandlePrice{}, fmt.Errorf("failed to get candle prices for %s", key)
+	}
+
+	candleList := []CandlePrice{}
+	for _, candle := range candles {
+		cp, err := candle.toCandlePrice()
+		if err != nil {
+			return []CandlePrice{}, err
+		}
+		candleList = append(candleList, cp)
+	}
+	return candleList, nil
+}
+
+func (p *MexcProvider) messageReceived(messageType int, bz []byte) {
+	if messageType != websocket.TextMessage {
+		return
+	}
+
+	var (
+		tickerResp MexcTicker
+		tickerErr  error
+		candleResp MexcCandle
+		candleErr  error
+	)
+
+	tickerErr = json.Unmarshal(bz, &tickerResp)
+	// TODO: Filter to only subscribed symbols
+	if len(tickerResp.LastPrice) != 0 {
+		p.setTickerPair(tickerResp)
+		telemetry.IncrCounter(
+			1,
+			"websocket",
+			"message",
+			"type",
+			"ticker",
+			"provider",
+			config.ProviderMexc,
+		)
+		return
+	}
+
+	candleErr = json.Unmarshal(bz, &candleResp)
+	// TODO: Adjust for MEXC response format
+	if len(candleResp.Metadata.Close) != 0 {
+		p.setCandlePair(candleResp)
+		telemetry.IncrCounter(
+			1,
+			"websocket",
+			"message",
+			"type",
+			"candle",
+			"provider",
+			config.ProviderMexc,
+		)
+		return
+	}
+
+	p.logger.Error().
+		Int("length", len(bz)).
+		AnErr("ticker", tickerErr).
+		AnErr("candle", candleErr).
+		Msg("Error on receive message")
+}
+
+func (p *MexcProvider) setTickerPair(ticker MexcTicker) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	p.tickers[ticker.Symbol] = ticker
+}
+
+func (p *MexcProvider) setCandlePair(candle MexcCandle) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	staleTime := PastUnixTime(providerCandlePeriod)
+	candleList := []MexcCandle{}
+	candleList = append(candleList, candle)
+
+	for _, c := range p.candles[candle.Symbol] {
+		if staleTime < c.Metadata.TimeStamp {
+			candleList = append(candleList, c)
+		}
+	}
+	p.candles[candle.Symbol] = candleList
+}
+
+func (ticker MexcTicker) toTickerPrice() (TickerPrice, error) {
+	return newTickerPrice("Mexc", ticker.Symbol, ticker.LastPrice, ticker.Volume)
+}
+
+func (candle MexcCandle) toCandlePrice() (CandlePrice, error) {
+	return newCandlePrice("Mexc", candle.Symbol, candle.Metadata.Close, candle.Metadata.Volume,
+		candle.Metadata.TimeStamp)
+}
+
+func (p *MexcProvider) handleWebSocketMsgs(ctx context.Context) {
+	reconnectTicker := time.NewTicker(defaultMaxConnectionTime)
+	defer reconnectTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(defaultReadNewWSMessage):
+			messageType, bz, err := p.wsClient.ReadMessage()
+			if err != nil {
+				// if some error occurs continue to try to read the next message.
+				p.logger.Err(err).Msg("could not read message")
+				continue
+			}
+
+			if len(bz) == 0 {
+				continue
+			}
+
+			p.messageReceived(messageType, bz)
+
+		case <-reconnectTicker.C:
+			if err := p.reconnect(); err != nil {
+				p.logger.Err(err).Msg("error reconnecting")
+				p.keepReconnecting()
+			}
+		}
+	}
+}
+
+// reconnect closes the last WS connection then create a new one and subscribe to
+// all subscribed pairs in the ticker and candle pairs. If no ping is received 
+// within 1 minute, the connection will be disconnected. It is recommended to 
+// send a ping for 10-20 seconds
+func (p *MexcProvider) reconnect() error {
+	p.wsClient.Close()
+
+	p.logger.Debug().Msg("reconnecting websocket")
+	wsConn, _, err := websocket.DefaultDialer.Dial(p.wsURL.String(), nil)
+	if err != nil {
+		return fmt.Errorf("error reconnect to mexc websocket: %w", err)
+	}
+	p.wsClient = wsConn
+
+	currencyPairs := p.subscribedPairsToSlice()
+
+	telemetry.IncrCounter(
+		1,
+		"websocket",
+		"reconnect",
+		"provider",
+		config.ProviderMexc,
+	)
+	return p.subscribeChannels(currencyPairs...)
+}
+
+// keepReconnecting keeps trying to reconnect if an error occurs in reconnect.
+func (p *MexcProvider) keepReconnecting() {
+	reconnectTicker := time.NewTicker(defaultReconnectTime)
+	defer reconnectTicker.Stop()
+	connectionTries := 1
+
+	for time := range reconnectTicker.C {
+		if err := p.reconnect(); err != nil {
+			p.logger.Err(err).Msgf("attempted to reconnect %d times at %s", connectionTries, time.String())
+			connectionTries++
+			continue
+		}
+
+		if connectionTries > maxReconnectionTries {
+			p.logger.Warn().Msgf("failed to reconnect %d times", connectionTries)
+		}
+		return
+	}
+}
+
+// setSubscribedPairs sets N currency pairs to the map of subscribed pairs.
+func (p *MexcProvider) setSubscribedPairs(cps ...types.CurrencyPair) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	for _, cp := range cps {
+		p.subscribedPairs[cp.String()] = cp
+	}
+}
+
+// subscribePairs write the subscription msg to the provider.
+func (p *MexcProvider) subscribePairs(pairs ...string) error {
+	for _, cp := range pairs {
+		subsMsg := newMexcCandleSubscriptionMsg(cp)
+		p.wsClient.WriteJSON(subsMsg)
+	}
+	subsMsg := newMexcTickerSubscriptionMsg()
+	return p.wsClient.WriteJSON(subsMsg)
+}
+
+// GetAvailablePairs returns all pairs to which the provider can subscribe.
+// ex.: map["ATOMUSDT" => {}, "UMEEUSDC" => {}].
+func (p *MexcProvider) GetAvailablePairs() (map[string]struct{}, error) {
+	resp, err := http.Get(p.endpoints.Rest + mexcRestPath)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var pairsSummary []MexcPairSummary
+	if err := json.NewDecoder(resp.Body).Decode(&pairsSummary); err != nil {
+		return nil, err
+	}
+
+	availablePairs := make(map[string]struct{}, len(pairsSummary))
+	for _, pairName := range pairsSummary {
+		availablePairs[strings.ToUpper(pairName.Symbol)] = struct{}{}
+	}
+
+	return availablePairs, nil
+}
+
+// // currencyPairToMexcTickerPair receives a currency pair and return mexc
+// // ticker symbol atomusdt@ticker.
+// func currencyPairToMexcTickerPair(cp types.CurrencyPair) string {
+// 	return strings.ToLower(cp.Base + "_" + cp.Quote)
+// }
+
+// // currencyPairToMexcCandlePair receives a currency pair and return mexc
+// // candle symbol atomusdt@kline_1m.
+// func currencyPairToMexcCandlePair(cp types.CurrencyPair) string {
+// 	return strings.ToLower(cp.String() + "@kline_1m")
+// }
+
+// currencyPairToMexcPair receives a currency pair and return mexc
+// ticker symbol atomusdt@ticker.
+func currencyPairToMexcPair(cp types.CurrencyPair) string {
+	return strings.ToLower(cp.Base + "_" + cp.Quote)
+}
+
+// newMexcSubscriptionMsg returns a new subscription Msg.
+func newMexcSubscriptionMsg(params ...string) MexcSubscriptionMsg {
+	return MexcSubscriptionMsg{
+		Method: "sub.kline",
+		Params: params,
+	}
+}
+
+// newMexcCandleSubscriptionMsg returns a new candle subscription Msg.
+func newMexcCandleSubscriptionMsg(param string) MexcCandleSubscriptionMsg {
+	return MexcSubscriptionMsg{
+		OP: "sub.kline",
+		Symbol: params,
+		Interval: "Min1",
+	}
+}
+
+// newMexcTickerSubscriptionMsg returns a new ticker subscription Msg.
+func newMexcTickerSubscriptionMsg() MexcTickerSubscriptionMsg {
+	return MexcSubscriptionMsg{
+		OP: "sub.overview",
+	}
+}

--- a/oracle/provider/mexc.go
+++ b/oracle/provider/mexc.go
@@ -21,7 +21,7 @@ import (
 const (
 	mexcWSHost   = "wbs.mexc.com"
 	mexcWSPath   = "/raw/ws"
-	mexcRestHost = "https://www.mexc.com/"
+	mexcRestHost = "https://www.mexc.com"
 	mexcRestPath = "/open/api/v2/market/ticker"
 	// mexcTicker   = "ticker"
 	// mexcCandle   = "kline"

--- a/oracle/provider/mexc.go
+++ b/oracle/provider/mexc.go
@@ -151,7 +151,7 @@ func (p *MexcProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]
 	tickerPrices := make(map[string]TickerPrice, len(pairs))
 
 	for _, cp := range pairs {
-		key := cp.String()
+		key := currencyPairToMexcPair(cp)
 		price, err := p.getTickerPrice(key)
 		if err != nil {
 			return nil, err

--- a/oracle/provider/mexc.go
+++ b/oracle/provider/mexc.go
@@ -327,7 +327,8 @@ func (p *MexcProvider) setTickerPair(symbol string, ticker MexcTickerData) {
 	mt.Symbol = symbol
 	mt.LastPrice = strconv.FormatFloat(ticker.LastPrice, 'f', 5, 64)
 	mt.Volume = strconv.FormatFloat(ticker.Volume, 'f', 5, 64)
-
+	msg := mt.Symbol + " - $" + mt.LastPrice + " - V: " + mt.Volume
+	p.logger.Warn().Msgf("mexc got price: %d", msg)
 	p.tickers[symbol] = mt
 
 }
@@ -344,6 +345,9 @@ func (p *MexcProvider) setCandlePair(candle MexcCandle) {
 			candleList = append(candleList, c)
 		}
 	}
+	msg := strconv.FormatInt(candle.Metadata.TimeStamp, 10) + " - " + candle.Symbol + " - C: $" + strconv.FormatFloat(candle.Metadata.Close, 'f', 5, 64) + " - V: " + strconv.FormatFloat(candle.Metadata.Volume, 'f', 5, 64)
+	p.logger.Warn().Msgf("mexc got candle: %d", msg)
+
 	p.candles[candle.Symbol] = candleList
 }
 

--- a/oracle/provider/mexc.go
+++ b/oracle/provider/mexc.go
@@ -43,8 +43,8 @@ type (
 		logger          zerolog.Logger
 		mtx             sync.RWMutex
 		endpoints       config.ProviderEndpoint
-		tickers         map[string]MexcTicker      // Symbol => MexcTicker
-		candles         map[string][]MexcCandle    // Symbol => MexcCandle
+		tickers         map[string]MexcTicker         // Symbol => MexcTicker
+		candles         map[string][]MexcCandle       // Symbol => MexcCandle
 		subscribedPairs map[string]types.CurrencyPair // Symbol => types.CurrencyPair
 	}
 
@@ -55,9 +55,9 @@ type (
 	// it avoids to implement specific UnmarshalJSON.
 	MexcTicker struct {
 		Symbol    string `json:"symbol"` // Symbol ex.: ATOM_USDT
-		LastPrice string `json:"last"` // Last price ex.: 0.0025
+		LastPrice string `json:"last"`   // Last price ex.: 0.0025
 		Volume    string `json:"volume"` // Total traded base asset volume ex.: 1000
-		C         uint64 `json:"C"` // Statistics close time
+		C         uint64 `json:"C"`      // Statistics close time
 	}
 
 	// MexcCandleMetadata candle metadata used to compute tvwap price.
@@ -70,26 +70,26 @@ type (
 	// MexcCandle candle Mexc websocket channel "kline_1m" response.
 	MexcCandle struct {
 		Symbol   string             `json:"symbol"` // Symbol ex.: BTCUSDT
-		Metadata MexcCandleMetadata `json:"data"` // Metadata for candle
+		Metadata MexcCandleMetadata `json:"data"`   // Metadata for candle
 	}
 
 	// MexcSubscribeMsg Msg to subscribe all the tickers channels.
 	MexcSubscriptionMsg struct {
-		Method string   `json:"op"` // SUBSCRIBE/UNSUBSCRIBE
-		Params []string `json:"symbol"` // streams to subscribe ex.: usdtatom@ticker
-		ID     uint16   `json:"channel"`     // identify messages going back and forth
+		Method string   `json:"op"`      // SUBSCRIBE/UNSUBSCRIBE
+		Params []string `json:"symbol"`  // streams to subscribe ex.: usdtatom@ticker
+		ID     uint16   `json:"channel"` // identify messages going back and forth
 	}
 
 	// MexcSubscribeMsg Msg to subscribe all the tickers channels.
 	MexcCandleSubscriptionMsg struct {
-		OP       string  `json:"op"` // kline
-		Symbol   string  `json:"symbol"` // streams to subscribe ex.: usdtatom@ticker
-		Interval string  `json:"interval"` // Min1、Min5、Min15、Min30
+		OP       string `json:"op"`       // kline
+		Symbol   string `json:"symbol"`   // streams to subscribe ex.: usdtatom@ticker
+		Interval string `json:"interval"` // Min1、Min5、Min15、Min30
 	}
 
 	// MexcSubscribeMsg Msg to subscribe all the tickers channels.
 	MexcTickerSubscriptionMsg struct {
-		OP string       `json:"op"` // kline
+		OP string `json:"op"` // kline
 	}
 
 	// MexcPairSummary defines the response structure for a Mexc pair
@@ -373,8 +373,8 @@ func (p *MexcProvider) handleWebSocketMsgs(ctx context.Context) {
 }
 
 // reconnect closes the last WS connection then create a new one and subscribe to
-// all subscribed pairs in the ticker and candle pairs. If no ping is received 
-// within 1 minute, the connection will be disconnected. It is recommended to 
+// all subscribed pairs in the ticker and candle pairs. If no ping is received
+// within 1 minute, the connection will be disconnected. It is recommended to
 // send a ping for 10-20 seconds
 func (p *MexcProvider) reconnect() error {
 	p.wsClient.Close()
@@ -478,26 +478,26 @@ func currencyPairToMexcPair(cp types.CurrencyPair) string {
 	return strings.ToLower(cp.Base + "_" + cp.Quote)
 }
 
-// newMexcSubscriptionMsg returns a new subscription Msg.
-func newMexcSubscriptionMsg(params ...string) MexcSubscriptionMsg {
-	return MexcSubscriptionMsg{
-		Method: "sub.kline",
-		Params: params,
-	}
-}
+// // newMexcSubscriptionMsg returns a new subscription Msg.
+// func newMexcSubscriptionMsg(params ...string) MexcSubscriptionMsg {
+// 	return MexcSubscriptionMsg{
+// 		Method: "sub.kline",
+// 		Params: params,
+// 	}
+// }
 
 // newMexcCandleSubscriptionMsg returns a new candle subscription Msg.
 func newMexcCandleSubscriptionMsg(param string) MexcCandleSubscriptionMsg {
-	return MexcSubscriptionMsg{
-		OP: "sub.kline",
-		Symbol: params,
+	return MexcCandleSubscriptionMsg{
+		OP:       "sub.kline",
+		Symbol:   param,
 		Interval: "Min1",
 	}
 }
 
 // newMexcTickerSubscriptionMsg returns a new ticker subscription Msg.
 func newMexcTickerSubscriptionMsg() MexcTickerSubscriptionMsg {
-	return MexcSubscriptionMsg{
+	return MexcTickerSubscriptionMsg{
 		OP: "sub.overview",
 	}
 }

--- a/oracle/provider/mexc.go
+++ b/oracle/provider/mexc.go
@@ -278,10 +278,6 @@ func (p *MexcProvider) messageReceived(messageType int, bz []byte) {
 	tickerErr = json.Unmarshal(bz, &tickerResp)
 	// subscribed_pairs := make([]string, 0, len(p.subscribedPairs))
 	for _, cp := range p.subscribedPairs {
-		// 	subscribed_pairs = append(subscribed_pairs, currencyPairToMexcPair(cp))
-		// }
-
-		// for i := range subscribed_pairs {
 		if tickerResp.Symbol[currencyPairToMexcPair(cp)].LastPrice != 0 {
 			p.setTickerPair(cp.String(), tickerResp.Symbol[currencyPairToMexcPair(cp)])
 			telemetry.IncrCounter(

--- a/oracle/provider/mexc_test.go
+++ b/oracle/provider/mexc_test.go
@@ -98,5 +98,5 @@ func TestMexcProvider_SubscribeCurrencyPairs(t *testing.T) {
 func TestMexcCurrencyPairToMexcPair(t *testing.T) {
 	cp := types.CurrencyPair{Base: "ATOM", Quote: "USDT"}
 	MexcSymbol := currencyPairToMexcPair(cp)
-	require.Equal(t, MexcSymbol, "atom_usdt")
+	require.Equal(t, MexcSymbol, "ATOM_USDT")
 }

--- a/oracle/provider/mexc_test.go
+++ b/oracle/provider/mexc_test.go
@@ -1,0 +1,102 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"price-feeder/config"
+	"price-feeder/oracle/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMexcProvider_GetTickerPrices(t *testing.T) {
+	p, err := NewMexcProvider(
+		context.TODO(),
+		zerolog.Nop(),
+		config.ProviderEndpoint{},
+		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
+	)
+	require.NoError(t, err)
+
+	t.Run("valid_request_single_ticker", func(t *testing.T) {
+		lastPrice := "34.69000000"
+		volume := "2396974.02000000"
+
+		tickerMap := map[string]MexcTicker{}
+		tickerMap["ATOMUSDT"] = MexcTicker{
+			Symbol:    "ATOMUSDT",
+			LastPrice: lastPrice,
+			Volume:    volume,
+		}
+
+		p.tickers = tickerMap
+
+		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+		require.NoError(t, err)
+		require.Len(t, prices, 1)
+		require.Equal(t, sdk.MustNewDecFromStr(lastPrice), prices["ATOMUSDT"].Price)
+		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["ATOMUSDT"].Volume)
+	})
+
+	t.Run("valid_request_multi_ticker", func(t *testing.T) {
+		lastPriceAtom := "34.69000000"
+		lastPriceLuna := "41.35000000"
+		volume := "2396974.02000000"
+
+		tickerMap := map[string]MexcTicker{}
+		tickerMap["ATOMUSDT"] = MexcTicker{
+			Symbol:    "ATOMUSDT",
+			LastPrice: lastPriceAtom,
+			Volume:    volume,
+		}
+
+		tickerMap["LUNAUSDT"] = MexcTicker{
+			Symbol:    "LUNAUSDT",
+			LastPrice: lastPriceLuna,
+			Volume:    volume,
+		}
+
+		p.tickers = tickerMap
+		prices, err := p.GetTickerPrices(
+			types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
+			types.CurrencyPair{Base: "LUNA", Quote: "USDT"},
+		)
+		require.NoError(t, err)
+		require.Len(t, prices, 2)
+		require.Equal(t, sdk.MustNewDecFromStr(lastPriceAtom), prices["ATOMUSDT"].Price)
+		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["ATOMUSDT"].Volume)
+		require.Equal(t, sdk.MustNewDecFromStr(lastPriceLuna), prices["LUNAUSDT"].Price)
+		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["LUNAUSDT"].Volume)
+	})
+
+	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {
+		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
+		require.Error(t, err)
+		require.Equal(t, "mexc provider failed to get ticker price for FOOBAR", err.Error())
+		require.Nil(t, prices)
+	})
+}
+
+func TestMexcProvider_SubscribeCurrencyPairs(t *testing.T) {
+	p, err := NewMexcProvider(
+		context.TODO(),
+		zerolog.Nop(),
+		config.ProviderEndpoint{},
+		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
+	)
+	require.NoError(t, err)
+
+	t.Run("invalid_subscribe_channels_empty", func(t *testing.T) {
+		err = p.SubscribeCurrencyPairs([]types.CurrencyPair{}...)
+		require.ErrorContains(t, err, "currency pairs is empty")
+	})
+}
+
+func TestMexcCurrencyPairToMexcPair(t *testing.T) {
+	cp := types.CurrencyPair{Base: "ATOM", Quote: "USDT"}
+	MexcSymbol := currencyPairToMexcPair(cp)
+	require.Equal(t, MexcSymbol, "atom_usdt")
+}


### PR DESCRIPTION
Provides ticker price and candle price from [MEXC](https://mxcdevelop.github.io/apidocs/spot_v2_en/#k-line)

Currently some periodic errors are occurring in the log - this is thought to be related to the large size of the `sub.overview` response - some improvement possible here, but does not appear to impact ticker and candle prices:

```
8:11PM ERR mexc: Error on receive message length=33390 module=oracle provider=mexc
8:12PM ERR mexc: Error on receive message length=37936 module=oracle provider=mexc
```