### PR TITLE
Dockerise and publish images on v* tags

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,5 @@
 build/
 config.toml
 .kujira
-.env
+Dockerfile
+docker-compose.yml

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,6 @@
 build/
 config.toml
 .kujira
+.env
 Dockerfile
 docker-compose.yml

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,16 @@
+name: publish
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: build
+        run: |
+          echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USER }}" --password-stdin
+          docker build . --tag ghcr.io/${{ github.repository }}:${GITHUB_REF#refs/tags/}
+          docker push ghcr.io/${{ github.repository }}:${GITHUB_REF#refs/tags/}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM golang:1.18-buster AS build
 
-WORKDIR /usr/lib
-RUN git clone https://github.com/Team-Kujira/core.git
-ADD . oracle-price-feeder
+ADD . /usr/lib/oracle-price-feeder
 WORKDIR /usr/lib/oracle-price-feeder
 RUN make install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.18-buster
+
+WORKDIR /usr/lib
+RUN git clone https://github.com/Team-Kujira/core.git
+ADD . oracle-price-feeder
+WORKDIR /usr/lib/oracle-price-feeder
+RUN make install
+
+RUN mkdir /root/.kujira
+WORKDIR /root/.kujira
+
+CMD price-feeder config.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN ldd /go/bin/price-feeder | tr -s '[:blank:]' '\n' | grep '^/' | \
 
 FROM debian:buster
 
+RUN apt-get update && apt-get install ca-certificates -y
+
 COPY --from=build /go/bin/price-feeder /bin/price-feeder
 COPY --from=build /deps /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,20 @@
-FROM golang:1.18-buster
+FROM golang:1.18-buster AS build
 
 WORKDIR /usr/lib
 RUN git clone https://github.com/Team-Kujira/core.git
 ADD . oracle-price-feeder
 WORKDIR /usr/lib/oracle-price-feeder
 RUN make install
+
+# locate and copy shared libraries to /deps
+# fixes missing libwasmvm.x86_64.so
+RUN ldd /go/bin/price-feeder | tr -s '[:blank:]' '\n' | grep '^/' | \
+    xargs -I % sh -c 'mkdir -p $(dirname /deps%); cp % /deps%;'
+
+FROM debian:buster
+
+COPY --from=build /go/bin/price-feeder /bin/price-feeder
+COPY --from=build /deps /
 
 RUN mkdir /root/.kujira
 WORKDIR /root/.kujira

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  feeder:
+    build: .
+    environment:
+      - PRICE_FEEDER_PASS=mypass
+    ports:
+      - "7171:7171"
+    volumes:
+      - ./.kujira:/root/.kujira


### PR DESCRIPTION
This adds a Dockerfile to build a container image, an example docker-compose file and a Github workflow to build and publish images on tag.

It would need `GHCR_USER` and `GHCR_TOKEN` secrets setting up on the repo or organisation to publish the images. Only `v*` tags would trigger a publish.