### PR TITLE
healthchecks and fin provider updates

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,5 @@
+FROM gitpod/workspace-base:latest
+
+ENV GO_VERSION=1.18.5
+RUN curl -fsSL https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz | tar xzs \
+    && echo "export GOPATH=$HOME/go\nexport PATH=$HOME/go/bin:$PATH" >> $HOME/.bashrc

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+# https://www.gitpod.io/docs/config-gitpod-file
+image:
+  file: .gitpod.Dockerfile

--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ The `rpc` section contains the Tendermint and Cosmos application gRPC endpoints.
 These endpoints are used to query for on-chain data that pertain to oracle
 functionality and for broadcasting signed pre-vote and vote oracle messages.
 
+### `healthchecks`
+
+The `healthchecks` section defines optional healthcheck endpoints to ping on successful
+oracle votes. This provides a simple alerting solution which can integrate with a service
+like [healthchecks.io](https://healthchecks.io). It's recommended to configure additional
+monitoring since third-party services can be unreliable.
+
 ## Keyring
 
 Our keyring must be set up to sign transactions before running the price feeder.

--- a/cmd/price-feeder.go
+++ b/cmd/price-feeder.go
@@ -169,6 +169,7 @@ func priceFeederCmdHandler(cmd *cobra.Command, args []string) error {
 		providerTimeout,
 		deviations,
 		endpoints,
+		cfg.Healthchecks,
 	)
 
 	telemetryCfg := telemetry.Config{}

--- a/config.example.toml
+++ b/config.example.toml
@@ -52,3 +52,6 @@ type = "prometheus"
 name = "binance"
 rest = "https://api1.binance.com"
 websocket = "stream.binance.com:9443"
+
+[[healthchecks]]
+url = "https://hc-ping.com/HEALTHCHECK-UUID"

--- a/config/config.go
+++ b/config/config.go
@@ -87,6 +87,7 @@ type (
 		ProviderEndpoints []ProviderEndpoint `toml:"provider_endpoints" validate:"dive"`
 		EnableServer      bool               `toml:"enable_server"`
 		EnableVoter       bool               `toml:"enable_voter"`
+		Healthchecks      []Healthchecks     `toml:"healthchecks" validate:"dive"`
 	}
 
 	// Server defines the API server configuration.
@@ -178,6 +179,10 @@ type (
 
 		// Websocket endpoint for the provider, ex. "stream.binance.com:9443"
 		Websocket string `toml:"websocket"`
+	}
+
+	Healthchecks struct {
+		URL string `toml:"url" validate:"required"`
 	}
 )
 

--- a/config/config.go
+++ b/config/config.go
@@ -183,6 +183,7 @@ type (
 
 	Healthchecks struct {
 		URL string `toml:"url" validate:"required"`
+		Timeout string `toml:"timeout" validate:"required"`
 	}
 )
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -47,6 +47,9 @@ func TestValidate(t *testing.T) {
 			},
 			GasAdjustment: 1.5,
 			GasPrices: "0.00125ukuji",
+			Healthchecks: []config.Healthchecks{
+				{URL: "https://hc-ping.com/HEALTHCHECK-UUID"},
+			},
 		}
 	}
 	emptyPairs := validConfig()
@@ -198,6 +201,9 @@ enable_hostname_label = true
 enable_service_label = true
 prometheus_retention = 120
 global_labels = [["chain-id", "kujira-local-testnet"]]
+
+[[healthchecks]]
+url = "https://hc-ping.com/HEALTHCHECK-UUID"
 `)
 	_, err = tmpFile.Write(content)
 	require.NoError(t, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -48,7 +48,7 @@ func TestValidate(t *testing.T) {
 			GasAdjustment: 1.5,
 			GasPrices: "0.00125ukuji",
 			Healthchecks: []config.Healthchecks{
-				{URL: "https://hc-ping.com/HEALTHCHECK-UUID"},
+				{URL: "https://hc-ping.com/HEALTHCHECK-UUID", Timeout: "200ms"},
 			},
 		}
 	}
@@ -204,6 +204,7 @@ global_labels = [["chain-id", "kujira-local-testnet"]]
 
 [[healthchecks]]
 url = "https://hc-ping.com/HEALTHCHECK-UUID"
+timeout = "200ms"
 `)
 	_, err = tmpFile.Write(content)
 	require.NoError(t, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,6 +25,7 @@ func TestValidate(t *testing.T) {
 				Address:   "fromaddr",
 				Validator: "valaddr",
 				ChainID:   "chain-id",
+				Prefix: "chain",
 			},
 			Keyring: config.Keyring{
 				Backend: "test",
@@ -45,6 +46,7 @@ func TestValidate(t *testing.T) {
 				PrometheusRetentionTime: 120,
 			},
 			GasAdjustment: 1.5,
+			GasPrices: "0.00125ukuji",
 		}
 	}
 	emptyPairs := validConfig()
@@ -137,6 +139,7 @@ func TestParseConfig_Valid(t *testing.T) {
 
 	content := []byte(`
 gas_adjustment = 1.5
+gas_prices = "0.00125ukuji"
 
 [server]
 listen_addr = "0.0.0.0:99999"
@@ -154,7 +157,7 @@ providers = [
 ]
 
 [[currency_pairs]]
-base = "UMEE"
+base = "KUJI"
 quote = "USDT"
 providers = [
 	"kraken",
@@ -172,13 +175,14 @@ providers = [
 ]
 
 [account]
-address = "umee15nejfgcaanqpw25ru4arvfd0fwy6j8clccvwx4"
-validator = "umeevalcons14rjlkfzp56733j5l5nfk6fphjxymgf8mj04d5p"
-chain_id = "umee-local-testnet"
+address = "kujira15nejfgcaanqpw25ru4arvfd0fwy6j8clccvwx4"
+validator = "kujiravalcons14rjlkfzp56733j5l5nfk6fphjxymgf8mj04d5p"
+chain_id = "kujira-local-testnet"
+prefix = "kujira"
 
 [keyring]
 backend = "test"
-dir = "/Users/username/.umee"
+dir = "/Users/username/.kujira"
 pass = "keyringPassword"
 
 [rpc]
@@ -193,7 +197,7 @@ enable_hostname = true
 enable_hostname_label = true
 enable_service_label = true
 prometheus_retention = 120
-global_labels = [["chain-id", "umee-local-testnet"]]
+global_labels = [["chain-id", "kujira-local-testnet"]]
 `)
 	_, err = tmpFile.Write(content)
 	require.NoError(t, err)
@@ -220,6 +224,7 @@ func TestParseConfig_Valid_NoTelemetry(t *testing.T) {
 
 	content := []byte(`
 gas_adjustment = 1.5
+gas_prices = "0.00125ukuji"
 
 [server]
 listen_addr = "0.0.0.0:99999"
@@ -237,7 +242,7 @@ providers = [
 ]
 
 [[currency_pairs]]
-base = "UMEE"
+base = "KUJI"
 quote = "USDT"
 providers = [
 	"kraken",
@@ -255,13 +260,14 @@ providers = [
 ]
 
 [account]
-address = "umee15nejfgcaanqpw25ru4arvfd0fwy6j8clccvwx4"
-validator = "umeevalcons14rjlkfzp56733j5l5nfk6fphjxymgf8mj04d5p"
-chain_id = "umee-local-testnet"
+address = "kujira15nejfgcaanqpw25ru4arvfd0fwy6j8clccvwx4"
+validator = "kujiravalcons14rjlkfzp56733j5l5nfk6fphjxymgf8mj04d5p"
+chain_id = "kujira-local-testnet"
+prefix = "kujira"
 
 [keyring]
 backend = "test"
-dir = "/Users/username/.umee"
+dir = "/Users/username/.kujira"
 pass = "keyringPassword"
 
 [rpc]
@@ -360,6 +366,7 @@ func TestParseConfig_Valid_Deviations(t *testing.T) {
 
 	content := []byte(`
 gas_adjustment = 1.5
+gas_prices = "0.00125ukuji"
 
 [server]
 listen_addr = "0.0.0.0:99999"
@@ -385,7 +392,7 @@ providers = [
 ]
 
 [[currency_pairs]]
-base = "UMEE"
+base = "KUJI"
 quote = "USDT"
 providers = [
 	"kraken",
@@ -403,13 +410,14 @@ providers = [
 ]
 
 [account]
-address = "umee15nejfgcaanqpw25ru4arvfd0fwy6j8clccvwx4"
-validator = "umeevalcons14rjlkfzp56733j5l5nfk6fphjxymgf8mj04d5p"
-chain_id = "umee-local-testnet"
+address = "kujira15nejfgcaanqpw25ru4arvfd0fwy6j8clccvwx4"
+validator = "kujiravalcons14rjlkfzp56733j5l5nfk6fphjxymgf8mj04d5p"
+chain_id = "kujira-local-testnet"
+prefix = "kujira"
 
 [keyring]
 backend = "test"
-dir = "/Users/username/.umee"
+dir = "/Users/username/.kujira"
 pass = "keyringPassword"
 
 [rpc]
@@ -424,7 +432,7 @@ enable_hostname = true
 enable_hostname_label = true
 enable_service_label = true
 prometheus_retention = 120
-global_labels = [["chain-id", "umee-local-testnet"]]
+global_labels = [["chain-id", "kujira-local-testnet"]]
 `)
 	_, err = tmpFile.Write(content)
 	require.NoError(t, err)

--- a/oracle/oracle_test.go
+++ b/oracle/oracle_test.go
@@ -108,6 +108,9 @@ func (ots *OracleTestSuite) SetupSuite() {
 		time.Millisecond*100,
 		make(map[string]sdk.Dec),
 		make(map[string]config.ProviderEndpoint),
+		[]config.Healthchecks{
+			{URL: "https://hc-ping.com/HEALTHCHECK-UUID", Timeout: "200ms"},
+		},
 	)
 }
 

--- a/oracle/provider/osmosis_test.go
+++ b/oracle/provider/osmosis_test.go
@@ -17,7 +17,7 @@ func TestOsmosisProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("valid_request_single_ticker", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			require.Equal(t, "/tokens/v1/all", req.URL.String())
+			require.Equal(t, "/tokens/v2/all", req.URL.String())
 			resp := `[
 				{
 					"price": 100.22,
@@ -53,7 +53,7 @@ func TestOsmosisProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("valid_request_multi_ticker", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			require.Equal(t, "/tokens/v1/all", req.URL.String())
+			require.Equal(t, "/tokens/v2/all", req.URL.String())
 			resp := `[
 				{
 					"price": 100.22,
@@ -94,7 +94,7 @@ func TestOsmosisProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("invalid_request_bad_response", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			require.Equal(t, "/tokens/v1/all", req.URL.String())
+			require.Equal(t, "/tokens/v2/all", req.URL.String())
 			rw.Write([]byte(`FOO`))
 		}))
 		defer server.Close()
@@ -109,7 +109,7 @@ func TestOsmosisProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			require.Equal(t, "/tokens/v1/all", req.URL.String())
+			require.Equal(t, "/tokens/v2/all", req.URL.String())
 			resp := `[
 				{
 					"price": 100.22,

--- a/oracle/provider/provider.go
+++ b/oracle/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"price-feeder/oracle/types"
@@ -108,4 +109,15 @@ func newCandlePrice(provider, symbol, lastPrice, volume string, timeStamp int64)
 // minus t.
 func PastUnixTime(t time.Duration) int64 {
 	return time.Now().Add(t*-1).Unix() * int64(time.Second/time.Millisecond)
+}
+
+func strToDec(str string) sdk.Dec {
+	if strings.Contains(str, ".") {
+		split := strings.Split(str, ".")
+		if len(split[1]) > 18 {
+			// sdk.MustNewDecFromStr will panic if decimal precision is greater than 18
+			str = split[0] + "." + split[1][0:18]
+		}
+	}
+	return sdk.MustNewDecFromStr(str)
 }


### PR DESCRIPTION
Inspired by https://github.com/eco-stake/restake, I implemented a very simple healthcheck that pings the configured URL on every successful vote. This lets you configure an alert with something like https://healthchecks.io to be notified if the regular pings stop coming in.

I also fixed some small issues with the FIN provider code and refactored strToDec so it can be used by other providers.

Also (I can split this into multiple PRs if needed) I fixed all the failing tests so running `make` works now.