### PR TITLE
improve feeder reliability

### DIFF
--- a/cmd/price-feeder.go
+++ b/cmd/price-feeder.go
@@ -124,6 +124,11 @@ func priceFeederCmdHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	heightPollInterval, err := time.ParseDuration(cfg.HeightPollInterval)
+	if err != nil {
+		return fmt.Errorf("failed to parse height poll interval: %w", err)
+	}
+
 	oracleClient, err := client.NewOracleClient(
 		ctx,
 		logger,
@@ -139,6 +144,7 @@ func priceFeederCmdHandler(cmd *cobra.Command, args []string) error {
 		cfg.RPC.GRPCEndpoint,
 		cfg.GasAdjustment,
 		cfg.GasPrices,
+		heightPollInterval,
 	)
 	if err != nil {
 		return err

--- a/cmd/price-feeder.go
+++ b/cmd/price-feeder.go
@@ -24,6 +24,7 @@ import (
 	"price-feeder/config"
 	"price-feeder/oracle"
 	"price-feeder/oracle/client"
+	"price-feeder/oracle/provider"
 	v1 "price-feeder/router/v1"
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
@@ -157,7 +158,7 @@ func priceFeederCmdHandler(cmd *cobra.Command, args []string) error {
 		deviations[deviation.Base] = threshold
 	}
 
-	endpoints := make(map[string]config.ProviderEndpoint, len(cfg.ProviderEndpoints))
+	endpoints := make(map[provider.Name]provider.Endpoint, len(cfg.ProviderEndpoints))
 	for _, endpoint := range cfg.ProviderEndpoints {
 		endpoints[endpoint.Name] = endpoint
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -79,6 +79,7 @@ type (
 		GasPrices         string             `toml:"gas_prices" validate:"required"`
 		ProviderTimeout   string             `toml:"provider_timeout"`
 		ProviderEndpoints []provider.Endpoint `toml:"provider_endpoints" validate:"dive"`
+		ProviderMinOverride bool `toml:"provider_min_override"`
 		EnableServer      bool               `toml:"enable_server"`
 		EnableVoter       bool               `toml:"enable_voter"`
 		Healthchecks      []Healthchecks     `toml:"healthchecks" validate:"dive"`
@@ -264,9 +265,11 @@ func ParseConfig(configPath string) (Config, error) {
 		}
 	}
 
-	for base, providers := range pairs {
-		if _, ok := pairs[base]["mock"]; !ok && len(providers) < 3 {
-			return cfg, fmt.Errorf("must have at least three providers for %s", base)
+	if !cfg.ProviderMinOverride {
+		for base, providers := range pairs {
+			if _, ok := pairs[base]["mock"]; !ok && len(providers) < 3 {
+				return cfg, fmt.Errorf("must have at least three providers for %s", base)
+			}
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ const (
 	defaultSrvWriteTimeout = 15 * time.Second
 	defaultSrvReadTimeout  = 15 * time.Second
 	defaultProviderTimeout = 100 * time.Millisecond
+	defaultHeightPollInterval = 1 * time.Second
 )
 
 var (
@@ -81,6 +82,7 @@ type (
 		EnableServer      bool               `toml:"enable_server"`
 		EnableVoter       bool               `toml:"enable_voter"`
 		Healthchecks      []Healthchecks     `toml:"healthchecks" validate:"dive"`
+		HeightPollInterval string `toml:"height_poll_interval"`
 	}
 
 	// Server defines the API server configuration.
@@ -224,6 +226,9 @@ func ParseConfig(configPath string) (Config, error) {
 	}
 	if len(cfg.ProviderTimeout) == 0 {
 		cfg.ProviderTimeout = defaultProviderTimeout.String()
+	}
+	if cfg.HeightPollInterval == "" {
+		cfg.HeightPollInterval = defaultHeightPollInterval.String()
 	}
 
 	pairs := make(map[string]map[provider.Name]struct{})

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/BurntSushi/toml"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/go-playground/validator/v10"
+	"price-feeder/oracle/provider"
 )
 
 const (
@@ -19,17 +20,6 @@ const (
 	defaultSrvWriteTimeout = 15 * time.Second
 	defaultSrvReadTimeout  = 15 * time.Second
 	defaultProviderTimeout = 100 * time.Millisecond
-
-	ProviderFin      = "fin"
-	ProviderKraken   = "kraken"
-	ProviderBinance  = "binance"
-	ProviderMexc     = "mexc"
-	ProviderOsmosis  = "osmosis"
-	ProviderHuobi    = "huobi"
-	ProviderOkx      = "okx"
-	ProviderGate     = "gate"
-	ProviderCoinbase = "coinbase"
-	ProviderMock     = "mock"
 )
 
 var (
@@ -40,17 +30,20 @@ var (
 
 	// SupportedProviders defines a lookup table of all the supported currency API
 	// providers.
-	SupportedProviders = map[string]struct{}{
-		ProviderFin:      {},
-		ProviderKraken:   {},
-		ProviderBinance:  {},
-		ProviderMexc:     {},
-		ProviderOsmosis:  {},
-		ProviderOkx:      {},
-		ProviderHuobi:    {},
-		ProviderGate:     {},
-		ProviderCoinbase: {},
-		ProviderMock:     {},
+	SupportedProviders = map[provider.Name]struct{}{
+		provider.ProviderKraken:    {},
+		provider.ProviderBinance:   {},
+		provider.ProviderBinanceUS: {},
+		provider.ProviderOsmosis:   {},
+		provider.ProviderOsmosisV2: {},
+		provider.ProviderOkx:       {},
+		provider.ProviderHuobi:     {},
+		provider.ProviderGate:      {},
+		provider.ProviderCoinbase:  {},
+		provider.ProviderBitget:    {},
+		provider.ProviderMexc:      {},
+		provider.ProviderCrypto:    {},
+		provider.ProviderMock:      {},
 	}
 
 	// maxDeviationThreshold is the maxmimum allowed amount of standard
@@ -84,7 +77,7 @@ type (
 		GasAdjustment     float64            `toml:"gas_adjustment" validate:"required"`
 		GasPrices         string             `toml:"gas_prices" validate:"required"`
 		ProviderTimeout   string             `toml:"provider_timeout"`
-		ProviderEndpoints []ProviderEndpoint `toml:"provider_endpoints" validate:"dive"`
+		ProviderEndpoints []provider.Endpoint `toml:"provider_endpoints" validate:"dive"`
 		EnableServer      bool               `toml:"enable_server"`
 		EnableVoter       bool               `toml:"enable_voter"`
 		Healthchecks      []Healthchecks     `toml:"healthchecks" validate:"dive"`
@@ -104,7 +97,7 @@ type (
 	CurrencyPair struct {
 		Base      string   `toml:"base" validate:"required"`
 		Quote     string   `toml:"quote" validate:"required"`
-		Providers []string `toml:"providers" validate:"required,gt=0,dive,required"`
+		Providers []provider.Name `toml:"providers" validate:"required,gt=0,dive,required"`
 	}
 
 	// Deviation defines a maximum amount of standard deviations that a given asset can
@@ -168,19 +161,6 @@ type (
 		PrometheusRetentionTime int64 `toml:"prometheus_retention" mapstructure:"prometheus-retention-time"`
 	}
 
-	// ProviderEndpoint defines an override setting in our config for the
-	// hardcoded rest and websocket api endpoints.
-	ProviderEndpoint struct {
-		// Name of the provider, ex. "binance"
-		Name string `toml:"name"`
-
-		// Rest endpoint for the provider, ex. "https://api1.binance.com"
-		Rest string `toml:"rest"`
-
-		// Websocket endpoint for the provider, ex. "stream.binance.com:9443"
-		Websocket string `toml:"websocket"`
-	}
-
 	Healthchecks struct {
 		URL string `toml:"url" validate:"required"`
 		Timeout string `toml:"timeout" validate:"required"`
@@ -198,7 +178,7 @@ func telemetryValidation(sl validator.StructLevel) {
 
 // endpointValidation is custom validation for the ProviderEndpoint struct.
 func endpointValidation(sl validator.StructLevel) {
-	endpoint := sl.Current().Interface().(ProviderEndpoint)
+	endpoint := sl.Current().Interface().(provider.Endpoint)
 
 	if len(endpoint.Name) < 1 || len(endpoint.Rest) < 1 || len(endpoint.Websocket) < 1 {
 		sl.ReportError(endpoint, "endpoint", "Endpoint", "unsupportedEndpointType", "")
@@ -211,7 +191,7 @@ func endpointValidation(sl validator.StructLevel) {
 // Validate returns an error if the Config object is invalid.
 func (c Config) Validate() error {
 	validate.RegisterStructValidation(telemetryValidation, Telemetry{})
-	validate.RegisterStructValidation(endpointValidation, ProviderEndpoint{})
+	validate.RegisterStructValidation(endpointValidation, provider.Endpoint{})
 	return validate.Struct(c)
 }
 
@@ -246,11 +226,11 @@ func ParseConfig(configPath string) (Config, error) {
 		cfg.ProviderTimeout = defaultProviderTimeout.String()
 	}
 
-	pairs := make(map[string]map[string]struct{})
+	pairs := make(map[string]map[provider.Name]struct{})
 	coinQuotes := make(map[string]struct{})
 	for _, cp := range cfg.CurrencyPairs {
 		if _, ok := pairs[cp.Base]; !ok {
-			pairs[cp.Base] = make(map[string]struct{})
+			pairs[cp.Base] = make(map[provider.Name]struct{})
 		}
 		if strings.ToUpper(cp.Quote) != DenomUSD {
 			coinQuotes[cp.Quote] = struct{}{}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"price-feeder/config"
+	"price-feeder/oracle/provider"
 
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +20,7 @@ func TestValidate(t *testing.T) {
 				AllowedOrigins: []string{},
 			},
 			CurrencyPairs: []config.CurrencyPair{
-				{Base: "ATOM", Quote: "USDT", Providers: []string{"kraken"}},
+				{Base: "ATOM", Quote: "USDT", Providers: []provider.Name{provider.ProviderKraken}},
 			},
 			Account: config.Account{
 				Address:   "fromaddr",
@@ -57,28 +58,28 @@ func TestValidate(t *testing.T) {
 
 	invalidBase := validConfig()
 	invalidBase.CurrencyPairs = []config.CurrencyPair{
-		{Base: "", Quote: "USDT", Providers: []string{"kraken"}},
+		{Base: "", Quote: "USDT", Providers: []provider.Name{provider.ProviderKraken}},
 	}
 
 	invalidQuote := validConfig()
 	invalidQuote.CurrencyPairs = []config.CurrencyPair{
-		{Base: "ATOM", Quote: "", Providers: []string{"kraken"}},
+		{Base: "ATOM", Quote: "", Providers: []provider.Name{provider.ProviderKraken}},
 	}
 
 	emptyProviders := validConfig()
 	emptyProviders.CurrencyPairs = []config.CurrencyPair{
-		{Base: "ATOM", Quote: "USDT", Providers: []string{}},
+		{Base: "ATOM", Quote: "USDT", Providers: []provider.Name{}},
 	}
 
 	invalidEndpoints := validConfig()
-	invalidEndpoints.ProviderEndpoints = []config.ProviderEndpoint{
+	invalidEndpoints.ProviderEndpoints = []provider.Endpoint{
 		{
-			Name: "binance",
+			Name: provider.ProviderBinance,
 		},
 	}
 
 	invalidEndpointsProvider := validConfig()
-	invalidEndpointsProvider.ProviderEndpoints = []config.ProviderEndpoint{
+	invalidEndpointsProvider.ProviderEndpoints = []provider.Endpoint{
 		{
 			Name:      "foo",
 			Rest:      "bar",
@@ -220,8 +221,8 @@ timeout = "200ms"
 	require.Equal(t, "ATOM", cfg.CurrencyPairs[0].Base)
 	require.Equal(t, "USDT", cfg.CurrencyPairs[0].Quote)
 	require.Len(t, cfg.CurrencyPairs[0].Providers, 3)
-	require.Equal(t, "kraken", cfg.CurrencyPairs[0].Providers[0])
-	require.Equal(t, "binance", cfg.CurrencyPairs[0].Providers[1])
+	require.Equal(t, provider.ProviderKraken, cfg.CurrencyPairs[0].Providers[0])
+	require.Equal(t, provider.ProviderBinance, cfg.CurrencyPairs[0].Providers[1])
 }
 
 func TestParseConfig_Valid_NoTelemetry(t *testing.T) {
@@ -299,8 +300,8 @@ enabled = false
 	require.Equal(t, "ATOM", cfg.CurrencyPairs[0].Base)
 	require.Equal(t, "USDT", cfg.CurrencyPairs[0].Quote)
 	require.Len(t, cfg.CurrencyPairs[0].Providers, 3)
-	require.Equal(t, "kraken", cfg.CurrencyPairs[0].Providers[0])
-	require.Equal(t, "binance", cfg.CurrencyPairs[0].Providers[1])
+	require.Equal(t, provider.ProviderKraken, cfg.CurrencyPairs[0].Providers[0])
+	require.Equal(t, provider.ProviderBinance, cfg.CurrencyPairs[0].Providers[1])
 	require.Equal(t, cfg.Telemetry.Enabled, false)
 }
 
@@ -455,8 +456,8 @@ global_labels = [["chain-id", "kujira-local-testnet"]]
 	require.Equal(t, "ATOM", cfg.CurrencyPairs[0].Base)
 	require.Equal(t, "USDT", cfg.CurrencyPairs[0].Quote)
 	require.Len(t, cfg.CurrencyPairs[0].Providers, 3)
-	require.Equal(t, "kraken", cfg.CurrencyPairs[0].Providers[0])
-	require.Equal(t, "binance", cfg.CurrencyPairs[0].Providers[1])
+	require.Equal(t, provider.ProviderKraken, cfg.CurrencyPairs[0].Providers[0])
+	require.Equal(t, provider.ProviderBinance, cfg.CurrencyPairs[0].Providers[1])
 	require.Equal(t, "2", cfg.Deviations[0].Threshold)
 	require.Equal(t, "USDT", cfg.Deviations[0].Base)
 	require.Equal(t, "1.5", cfg.Deviations[1].Threshold)

--- a/oracle/client/chain_height.go
+++ b/oracle/client/chain_height.go
@@ -2,111 +2,71 @@ package client
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"sync"
+	"time"
 
 	"github.com/rs/zerolog"
 	tmrpcclient "github.com/tendermint/tendermint/rpc/client"
-	tmctypes "github.com/tendermint/tendermint/rpc/core/types"
-	tmtypes "github.com/tendermint/tendermint/types"
 )
 
-var (
-	errParseEventDataNewBlockHeader = errors.New("error parsing EventDataNewBlockHeader")
-	queryEventNewBlockHeader        = tmtypes.QueryForEvent(tmtypes.EventNewBlockHeader)
-)
-
-// ChainHeight is used to cache the chain height of the
-// current node which is being updated each time the
-// node sends an event of EventNewBlockHeader.
-// It starts a goroutine to subscribe to blockchain new block event and update the cached height.
 type ChainHeight struct {
 	Logger zerolog.Logger
-
-	mtx               sync.RWMutex
-	errGetChainHeight error
-	lastChainHeight   int64
+	ctx context.Context
+	rpc tmrpcclient.Client
+	pollInterval time.Duration
+	height int64
+	err error
 }
 
-// NewChainHeight returns a new ChainHeight struct that
-// starts a new goroutine subscribed to EventNewBlockHeader.
 func NewChainHeight(
 	ctx context.Context,
-	rpcClient tmrpcclient.Client,
+	rpc tmrpcclient.Client,
 	logger zerolog.Logger,
-	initialHeight int64,
+	pollInterval time.Duration,
 ) (*ChainHeight, error) {
-	if initialHeight < 1 {
-		return nil, fmt.Errorf("expected positive initial block height")
-	}
-
-	if !rpcClient.IsRunning() {
-		if err := rpcClient.Start(); err != nil {
+	if !rpc.IsRunning() {
+		err := rpc.Start()
+		if err != nil {
 			return nil, err
 		}
 	}
-
-	newBlockHeaderSubscription, err := rpcClient.Subscribe(
-		ctx, tmtypes.EventNewBlockHeader, queryEventNewBlockHeader.String())
-	if err != nil {
-		return nil, err
+	c := &ChainHeight{
+		Logger: logger.With().Str("oracle_client", "chain_height").Logger(),
+		ctx: ctx,
+		rpc: rpc,
+		height: 0,
+		pollInterval: pollInterval,
+		err: nil,
 	}
-
-	chainHeight := &ChainHeight{
-		Logger:            logger.With().Str("oracle_client", "chain_height").Logger(),
-		errGetChainHeight: nil,
-		lastChainHeight:   initialHeight,
-	}
-
-	go chainHeight.subscribe(ctx, rpcClient, newBlockHeaderSubscription)
-
-	return chainHeight, nil
+	c.update()
+	go c.poll()
+	return c, c.err
 }
 
-// updateChainHeight receives the data to be updated thread safe.
-func (chainHeight *ChainHeight) updateChainHeight(blockHeight int64, err error) {
-	chainHeight.mtx.Lock()
-	defer chainHeight.mtx.Unlock()
-
-	chainHeight.lastChainHeight = blockHeight
-	chainHeight.errGetChainHeight = err
-}
-
-// subscribe listens to new blocks being made
-// and updates the chain height.
-func (chainHeight *ChainHeight) subscribe(
-	ctx context.Context,
-	eventsClient tmrpcclient.EventsClient,
-	newBlockHeaderSubscription <-chan tmctypes.ResultEvent,
-) {
+func (c *ChainHeight) poll() {
 	for {
-		select {
-		case <-ctx.Done():
-			err := eventsClient.Unsubscribe(ctx, tmtypes.EventNewBlockHeader, queryEventNewBlockHeader.String())
-			if err != nil {
-				chainHeight.Logger.Err(err)
-				chainHeight.updateChainHeight(chainHeight.lastChainHeight, err)
-			}
-			chainHeight.Logger.Info().Msg("closing the ChainHeight subscription")
-			return
-
-		case resultEvent := <-newBlockHeaderSubscription:
-			eventDataNewBlockHeader, ok := resultEvent.Data.(tmtypes.EventDataNewBlockHeader)
-			if !ok {
-				chainHeight.Logger.Err(errParseEventDataNewBlockHeader)
-				chainHeight.updateChainHeight(chainHeight.lastChainHeight, errParseEventDataNewBlockHeader)
-				continue
-			}
-			chainHeight.updateChainHeight(eventDataNewBlockHeader.Header.Height, nil)
-		}
+		time.Sleep(c.pollInterval)
+		c.update()
 	}
 }
 
-// GetChainHeight returns the last chain height available.
-func (chainHeight *ChainHeight) GetChainHeight() (int64, error) {
-	chainHeight.mtx.RLock()
-	defer chainHeight.mtx.RUnlock()
+func (c *ChainHeight) update() {
+	status, err := c.rpc.Status(c.ctx)
+	if err == nil {
+		if c.height < status.SyncInfo.LatestBlockHeight {
+			c.height = status.SyncInfo.LatestBlockHeight
+			c.Logger.Info().Int64("height", c.height).Msg("got new chain height")
+		} else {
+			c.Logger.Debug().
+				Int64("new", status.SyncInfo.LatestBlockHeight).
+				Int64("current", c.height).
+				Msg("ignoring stale chain height")
+		}
+	} else {
+		c.Logger.Warn().Err(err).Msg("failed to get chain height")
+	}
+	c.err = err
+}
 
-	return chainHeight.lastChainHeight, chainHeight.errGetChainHeight
+func (c *ChainHeight) GetChainHeight() (int64, error) {
+	return c.height, c.err
 }

--- a/oracle/client/client.go
+++ b/oracle/client/client.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/client/rpc"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/telemetry"
@@ -70,6 +69,7 @@ func NewOracleClient(
 	grpcEndpoint string,
 	gasAdjustment float64,
 	gasPrices string,
+	heightPollInterval time.Duration,
 ) (OracleClient, error) {
 	oracleAddr, err := sdk.AccAddressFromBech32(oracleAddrString)
 	if err != nil {
@@ -102,16 +102,11 @@ func NewOracleClient(
 		return OracleClient{}, err
 	}
 
-	blockHeight, err := rpc.GetChainHeight(clientCtx)
-	if err != nil {
-		return OracleClient{}, err
-	}
-
 	chainHeight, err := NewChainHeight(
 		ctx,
 		clientCtx.Client,
 		oracleClient.Logger,
-		blockHeight,
+		heightPollInterval,
 	)
 	if err != nil {
 		return OracleClient{}, err

--- a/oracle/convert_test.go
+++ b/oracle/convert_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"price-feeder/config"
 	"price-feeder/oracle/provider"
 	"price-feeder/oracle/types"
 
@@ -30,7 +29,7 @@ var (
 )
 
 func TestGetUSDBasedProviders(t *testing.T) {
-	providerPairs := make(map[string][]types.CurrencyPair, 3)
+	providerPairs := make(map[provider.Name][]types.CurrencyPair, 3)
 	providerPairs["coinbase"] = []types.CurrencyPair{
 		{
 			Base:  "FOO",
@@ -58,7 +57,7 @@ func TestGetUSDBasedProviders(t *testing.T) {
 
 	pairs, err := getUSDBasedProviders("FOO", providerPairs)
 	require.NoError(t, err)
-	expectedPairs := map[string]struct{}{
+	expectedPairs := map[provider.Name]struct{}{
 		"coinbase": {},
 		"huobi":    {},
 	}
@@ -66,39 +65,39 @@ func TestGetUSDBasedProviders(t *testing.T) {
 
 	pairs, err = getUSDBasedProviders("USDT", providerPairs)
 	require.NoError(t, err)
-	expectedPairs = map[string]struct{}{
+	expectedPairs = map[provider.Name]struct{}{
 		"binance": {},
 	}
 	require.Equal(t, pairs, expectedPairs)
 
-	pairs, err = getUSDBasedProviders("BAR", providerPairs)
+	_, err = getUSDBasedProviders("BAR", providerPairs)
 	require.Error(t, err)
 }
 
 func TestConvertCandlesToUSD(t *testing.T) {
 	providerCandles := make(provider.AggregatedProviderCandles, 2)
 
-	binanceCandles := map[string][]provider.CandlePrice{
+	binanceCandles := map[string][]types.CandlePrice{
 		"ATOM": {{
 			Price:     atomPrice,
 			Volume:    atomVolume,
 			TimeStamp: provider.PastUnixTime(1 * time.Minute),
 		}},
 	}
-	providerCandles[config.ProviderBinance] = binanceCandles
+	providerCandles[provider.ProviderBinance] = binanceCandles
 
-	krakenCandles := map[string][]provider.CandlePrice{
+	krakenCandles := map[string][]types.CandlePrice{
 		"USDT": {{
 			Price:     usdtPrice,
 			Volume:    usdtVolume,
 			TimeStamp: provider.PastUnixTime(1 * time.Minute),
 		}},
 	}
-	providerCandles[config.ProviderKraken] = krakenCandles
+	providerCandles[provider.ProviderKraken] = krakenCandles
 
-	providerPairs := map[string][]types.CurrencyPair{
-		config.ProviderBinance: {atomPair},
-		config.ProviderKraken:  {usdtPair},
+	providerPairs := map[provider.Name][]types.CurrencyPair{
+		provider.ProviderBinance: {atomPair},
+		provider.ProviderKraken:  {usdtPair},
 	}
 
 	convertedCandles, err := convertCandlesToUSD(
@@ -119,47 +118,47 @@ func TestConvertCandlesToUSD(t *testing.T) {
 func TestConvertCandlesToUSDFiltering(t *testing.T) {
 	providerCandles := make(provider.AggregatedProviderCandles, 2)
 
-	binanceCandles := map[string][]provider.CandlePrice{
+	binanceCandles := map[string][]types.CandlePrice{
 		"ATOM": {{
 			Price:     atomPrice,
 			Volume:    atomVolume,
 			TimeStamp: provider.PastUnixTime(1 * time.Minute),
 		}},
 	}
-	providerCandles[config.ProviderBinance] = binanceCandles
+	providerCandles[provider.ProviderBinance] = binanceCandles
 
-	krakenCandles := map[string][]provider.CandlePrice{
+	krakenCandles := map[string][]types.CandlePrice{
 		"USDT": {{
 			Price:     usdtPrice,
 			Volume:    usdtVolume,
 			TimeStamp: provider.PastUnixTime(1 * time.Minute),
 		}},
 	}
-	providerCandles[config.ProviderKraken] = krakenCandles
+	providerCandles[provider.ProviderKraken] = krakenCandles
 
-	gateCandles := map[string][]provider.CandlePrice{
+	gateCandles := map[string][]types.CandlePrice{
 		"USDT": {{
 			Price:     usdtPrice,
 			Volume:    usdtVolume,
 			TimeStamp: provider.PastUnixTime(1 * time.Minute),
 		}},
 	}
-	providerCandles[config.ProviderGate] = gateCandles
+	providerCandles[provider.ProviderGate] = gateCandles
 
-	okxCandles := map[string][]provider.CandlePrice{
+	okxCandles := map[string][]types.CandlePrice{
 		"USDT": {{
 			Price:     sdk.MustNewDecFromStr("100.0"),
 			Volume:    usdtVolume,
 			TimeStamp: provider.PastUnixTime(1 * time.Minute),
 		}},
 	}
-	providerCandles[config.ProviderOkx] = okxCandles
+	providerCandles[provider.ProviderOkx] = okxCandles
 
-	providerPairs := map[string][]types.CurrencyPair{
-		config.ProviderBinance: {atomPair},
-		config.ProviderKraken:  {usdtPair},
-		config.ProviderGate:    {usdtPair},
-		config.ProviderOkx:     {usdtPair},
+	providerPairs := map[provider.Name][]types.CurrencyPair{
+		provider.ProviderBinance: {atomPair},
+		provider.ProviderKraken:  {usdtPair},
+		provider.ProviderGate:    {usdtPair},
+		provider.ProviderOkx:     {usdtPair},
 	}
 
 	convertedCandles, err := convertCandlesToUSD(
@@ -180,25 +179,25 @@ func TestConvertCandlesToUSDFiltering(t *testing.T) {
 func TestConvertTickersToUSD(t *testing.T) {
 	providerPrices := make(provider.AggregatedProviderPrices, 2)
 
-	binanceTickers := map[string]provider.TickerPrice{
+	binanceTickers := map[string]types.TickerPrice{
 		"ATOM": {
 			Price:  atomPrice,
 			Volume: atomVolume,
 		},
 	}
-	providerPrices[config.ProviderBinance] = binanceTickers
+	providerPrices[provider.ProviderBinance] = binanceTickers
 
-	krakenTicker := map[string]provider.TickerPrice{
+	krakenTicker := map[string]types.TickerPrice{
 		"USDT": {
 			Price:  usdtPrice,
 			Volume: usdtVolume,
 		},
 	}
-	providerPrices[config.ProviderKraken] = krakenTicker
+	providerPrices[provider.ProviderKraken] = krakenTicker
 
-	providerPairs := map[string][]types.CurrencyPair{
-		config.ProviderBinance: {atomPair},
-		config.ProviderKraken:  {usdtPair},
+	providerPairs := map[provider.Name][]types.CurrencyPair{
+		provider.ProviderBinance: {atomPair},
+		provider.ProviderKraken:  {usdtPair},
 	}
 
 	convertedTickers, err := convertTickersToUSD(
@@ -219,40 +218,40 @@ func TestConvertTickersToUSD(t *testing.T) {
 func TestConvertTickersToUSDFiltering(t *testing.T) {
 	providerPrices := make(provider.AggregatedProviderPrices, 2)
 
-	binanceTickers := map[string]provider.TickerPrice{
+	binanceTickers := map[string]types.TickerPrice{
 		"ATOM": {
 			Price:  atomPrice,
 			Volume: atomVolume,
 		},
 	}
-	providerPrices[config.ProviderBinance] = binanceTickers
+	providerPrices[provider.ProviderBinance] = binanceTickers
 
-	krakenTicker := map[string]provider.TickerPrice{
+	krakenTicker := map[string]types.TickerPrice{
 		"USDT": {
 			Price:  usdtPrice,
 			Volume: usdtVolume,
 		},
 	}
-	providerPrices[config.ProviderKraken] = krakenTicker
+	providerPrices[provider.ProviderKraken] = krakenTicker
 
-	gateTicker := map[string]provider.TickerPrice{
+	gateTicker := map[string]types.TickerPrice{
 		"USDT": krakenTicker["USDT"],
 	}
-	providerPrices[config.ProviderGate] = gateTicker
+	providerPrices[provider.ProviderGate] = gateTicker
 
-	huobiTicker := map[string]provider.TickerPrice{
+	huobiTicker := map[string]types.TickerPrice{
 		"USDT": {
 			Price:  sdk.MustNewDecFromStr("10000"),
 			Volume: usdtVolume,
 		},
 	}
-	providerPrices[config.ProviderHuobi] = huobiTicker
+	providerPrices[provider.ProviderHuobi] = huobiTicker
 
-	providerPairs := map[string][]types.CurrencyPair{
-		config.ProviderBinance: {atomPair},
-		config.ProviderKraken:  {usdtPair},
-		config.ProviderGate:    {usdtPair},
-		config.ProviderHuobi:   {usdtPair},
+	providerPairs := map[provider.Name][]types.CurrencyPair{
+		provider.ProviderBinance: {atomPair},
+		provider.ProviderKraken:  {usdtPair},
+		provider.ProviderGate:    {usdtPair},
+		provider.ProviderHuobi:   {usdtPair},
 	}
 
 	covertedDeviation, err := convertTickersToUSD(

--- a/oracle/filter_test.go
+++ b/oracle/filter_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"price-feeder/config"
 	"price-feeder/oracle/provider"
 	"price-feeder/oracle/types"
 
@@ -23,7 +22,7 @@ func TestSuccessFilterCandleDeviations(t *testing.T) {
 	atomPrice := sdk.MustNewDecFromStr("29.93")
 	atomVolume := sdk.MustNewDecFromStr("1994674.34000000")
 
-	atomCandlePrice := []provider.CandlePrice{
+	atomCandlePrice := []types.CandlePrice{
 		{
 			Price:     atomPrice,
 			Volume:    atomVolume,
@@ -31,16 +30,16 @@ func TestSuccessFilterCandleDeviations(t *testing.T) {
 		},
 	}
 
-	providerCandles[config.ProviderBinance] = map[string][]provider.CandlePrice{
+	providerCandles[provider.ProviderBinance] = map[string][]types.CandlePrice{
 		pair.Base: atomCandlePrice,
 	}
-	providerCandles[config.ProviderHuobi] = map[string][]provider.CandlePrice{
+	providerCandles[provider.ProviderHuobi] = map[string][]types.CandlePrice{
 		pair.Base: atomCandlePrice,
 	}
-	providerCandles[config.ProviderKraken] = map[string][]provider.CandlePrice{
+	providerCandles[provider.ProviderKraken] = map[string][]types.CandlePrice{
 		pair.Base: atomCandlePrice,
 	}
-	providerCandles[config.ProviderCoinbase] = map[string][]provider.CandlePrice{
+	providerCandles[provider.ProviderCoinbase] = map[string][]types.CandlePrice{
 		pair.Base: {
 			{
 				Price:     sdk.MustNewDecFromStr("27.1"),
@@ -56,7 +55,7 @@ func TestSuccessFilterCandleDeviations(t *testing.T) {
 		make(map[string]sdk.Dec),
 	)
 
-	_, ok := pricesFiltered[config.ProviderCoinbase]
+	_, ok := pricesFiltered[provider.ProviderCoinbase]
 	require.NoError(t, err, "It should successfully filter out the provider using candles")
 	require.False(t, ok, "The filtered candle deviation price at coinbase should be empty")
 
@@ -69,7 +68,7 @@ func TestSuccessFilterCandleDeviations(t *testing.T) {
 		customDeviations,
 	)
 
-	_, ok = pricesFilteredCustom[config.ProviderCoinbase]
+	_, ok = pricesFilteredCustom[provider.ProviderCoinbase]
 	require.NoError(t, err, "It should successfully not filter out coinbase")
 	require.True(t, ok, "The filtered candle deviation price of coinbase should remain")
 }
@@ -84,21 +83,21 @@ func TestSuccessFilterTickerDeviations(t *testing.T) {
 	atomPrice := sdk.MustNewDecFromStr("29.93")
 	atomVolume := sdk.MustNewDecFromStr("1994674.34000000")
 
-	atomTickerPrice := provider.TickerPrice{
+	atomTickerPrice := types.TickerPrice{
 		Price:  atomPrice,
 		Volume: atomVolume,
 	}
 
-	providerTickers[config.ProviderBinance] = map[string]provider.TickerPrice{
+	providerTickers[provider.ProviderBinance] = map[string]types.TickerPrice{
 		pair.Base: atomTickerPrice,
 	}
-	providerTickers[config.ProviderHuobi] = map[string]provider.TickerPrice{
+	providerTickers[provider.ProviderHuobi] = map[string]types.TickerPrice{
 		pair.Base: atomTickerPrice,
 	}
-	providerTickers[config.ProviderKraken] = map[string]provider.TickerPrice{
+	providerTickers[provider.ProviderKraken] = map[string]types.TickerPrice{
 		pair.Base: atomTickerPrice,
 	}
-	providerTickers[config.ProviderCoinbase] = map[string]provider.TickerPrice{
+	providerTickers[provider.ProviderCoinbase] = map[string]types.TickerPrice{
 		pair.Base: {
 			Price:  sdk.MustNewDecFromStr("27.1"),
 			Volume: atomVolume,
@@ -111,7 +110,7 @@ func TestSuccessFilterTickerDeviations(t *testing.T) {
 		make(map[string]sdk.Dec),
 	)
 
-	_, ok := pricesFiltered[config.ProviderCoinbase]
+	_, ok := pricesFiltered[provider.ProviderCoinbase]
 	require.NoError(t, err, "It should successfully filter out the provider using tickers")
 	require.False(t, ok, "The filtered ticker deviation price at coinbase should be empty")
 
@@ -124,7 +123,7 @@ func TestSuccessFilterTickerDeviations(t *testing.T) {
 		customDeviations,
 	)
 
-	_, ok = pricesFilteredCustom[config.ProviderCoinbase]
+	_, ok = pricesFilteredCustom[provider.ProviderCoinbase]
 	require.NoError(t, err, "It should successfully not filter out coinbase")
 	require.True(t, ok, "The filtered candle deviation price of coinbase should remain")
 }

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -59,13 +59,13 @@ type Oracle struct {
 	closer *pfsync.Closer
 
 	providerTimeout    time.Duration
-	providerPairs      map[string][]types.CurrencyPair
+	providerPairs      map[provider.Name][]types.CurrencyPair
 	previousPrevote    *PreviousPrevote
 	previousVotePeriod float64
-	priceProviders     map[string]provider.Provider
+	priceProviders     map[provider.Name]provider.Provider
 	oracleClient       client.OracleClient
 	deviations         map[string]sdk.Dec
-	endpoints          map[string]config.ProviderEndpoint
+	endpoints          map[provider.Name]provider.Endpoint
 
 	mtx             sync.RWMutex
 	lastPriceSyncTS time.Time
@@ -80,10 +80,10 @@ func New(
 	currencyPairs []config.CurrencyPair,
 	providerTimeout time.Duration,
 	deviations map[string]sdk.Dec,
-	endpoints map[string]config.ProviderEndpoint,
+	endpoints map[provider.Name]provider.Endpoint,
 	healthchecksConfig []config.Healthchecks,
 ) *Oracle {
-	providerPairs := make(map[string][]types.CurrencyPair)
+	providerPairs := make(map[provider.Name][]types.CurrencyPair)
 
 	for _, pair := range currencyPairs {
 		for _, provider := range pair.Providers {
@@ -113,7 +113,7 @@ func New(
 		closer:          pfsync.NewCloser(),
 		oracleClient:    oc,
 		providerPairs:   providerPairs,
-		priceProviders:  make(map[string]provider.Provider),
+		priceProviders:  make(map[provider.Name]provider.Provider),
 		previousPrevote: nil,
 		providerTimeout: providerTimeout,
 		deviations:      deviations,
@@ -208,8 +208,8 @@ func (o *Oracle) SetPrices(ctx context.Context) error {
 		}
 
 		g.Go(func() error {
-			prices := make(map[string]provider.TickerPrice, 0)
-			candles := make(map[string][]provider.CandlePrice, 0)
+			prices := make(map[string]types.TickerPrice, 0)
+			candles := make(map[string][]types.CandlePrice, 0)
 			ch := make(chan struct{})
 			errCh := make(chan error, 1)
 
@@ -291,7 +291,7 @@ func GetComputedPrices(
 	logger zerolog.Logger,
 	providerCandles provider.AggregatedProviderCandles,
 	providerPrices provider.AggregatedProviderPrices,
-	providerPairs map[string][]types.CurrencyPair,
+	providerPairs map[provider.Name][]types.CurrencyPair,
 	deviations map[string]sdk.Dec,
 ) (prices map[string]sdk.Dec, err error) {
 	// convert any non-USD denominated candles into USD
@@ -358,18 +358,18 @@ func GetComputedPrices(
 // candles and tickers based on the base currency per provider.
 // Returns true if at least one of price or candle exists.
 func SetProviderTickerPricesAndCandles(
-	providerName string,
+	providerName provider.Name,
 	providerPrices provider.AggregatedProviderPrices,
 	providerCandles provider.AggregatedProviderCandles,
-	prices map[string]provider.TickerPrice,
-	candles map[string][]provider.CandlePrice,
+	prices map[string]types.TickerPrice,
+	candles map[string][]types.CandlePrice,
 	pair types.CurrencyPair,
 ) (success bool) {
 	if _, ok := providerPrices[providerName]; !ok {
-		providerPrices[providerName] = make(map[string]provider.TickerPrice)
+		providerPrices[providerName] = make(map[string]types.TickerPrice)
 	}
 	if _, ok := providerCandles[providerName]; !ok {
-		providerCandles[providerName] = make(map[string][]provider.CandlePrice)
+		providerCandles[providerName] = make(map[string][]types.CandlePrice)
 	}
 
 	tp, pricesOk := prices[pair.String()]
@@ -428,7 +428,7 @@ func (o *Oracle) GetParams(ctx context.Context) (oracletypes.Params, error) {
 	return queryResponse.Params, nil
 }
 
-func (o *Oracle) getOrSetProvider(ctx context.Context, providerName string) (provider.Provider, error) {
+func (o *Oracle) getOrSetProvider(ctx context.Context, providerName provider.Name) (provider.Provider, error) {
 	var (
 		priceProvider provider.Provider
 		ok            bool
@@ -456,40 +456,49 @@ func (o *Oracle) getOrSetProvider(ctx context.Context, providerName string) (pro
 
 func NewProvider(
 	ctx context.Context,
-	providerName string,
+	providerName provider.Name,
 	logger zerolog.Logger,
-	endpoint config.ProviderEndpoint,
+	endpoint provider.Endpoint,
 	providerPairs ...types.CurrencyPair,
 ) (provider.Provider, error) {
 	switch providerName {
-	case config.ProviderFin:
-		return provider.NewFinProvider(endpoint), nil
+	case provider.ProviderBinance:
+		return provider.NewBinanceProvider(ctx, logger, endpoint, false, providerPairs...)
 
-	case config.ProviderBinance:
-		return provider.NewBinanceProvider(ctx, logger, endpoint, providerPairs...)
+	case provider.ProviderBinanceUS:
+		return provider.NewBinanceProvider(ctx, logger, endpoint, true, providerPairs...)
 
-	case config.ProviderKraken:
+	case provider.ProviderKraken:
 		return provider.NewKrakenProvider(ctx, logger, endpoint, providerPairs...)
 
-	case config.ProviderMexc:
-		return provider.NewMexcProvider(ctx, logger, endpoint, providerPairs...)
-
-	case config.ProviderOsmosis:
+	case provider.ProviderOsmosis:
 		return provider.NewOsmosisProvider(endpoint), nil
 
-	case config.ProviderHuobi:
+	case provider.ProviderOsmosisV2:
+		return provider.NewOsmosisV2Provider(ctx, logger, endpoint, providerPairs...)
+
+	case provider.ProviderHuobi:
 		return provider.NewHuobiProvider(ctx, logger, endpoint, providerPairs...)
 
-	case config.ProviderCoinbase:
+	case provider.ProviderCoinbase:
 		return provider.NewCoinbaseProvider(ctx, logger, endpoint, providerPairs...)
 
-	case config.ProviderOkx:
+	case provider.ProviderOkx:
 		return provider.NewOkxProvider(ctx, logger, endpoint, providerPairs...)
 
-	case config.ProviderGate:
+	case provider.ProviderGate:
 		return provider.NewGateProvider(ctx, logger, endpoint, providerPairs...)
 
-	case config.ProviderMock:
+	case provider.ProviderBitget:
+		return provider.NewBitgetProvider(ctx, logger, endpoint, providerPairs...)
+
+	case provider.ProviderMexc:
+		return provider.NewMexcProvider(ctx, logger, endpoint, providerPairs...)
+
+	case provider.ProviderCrypto:
+		return provider.NewCryptoProvider(ctx, logger, endpoint, providerPairs...)
+
+	case provider.ProviderMock:
 		return provider.NewMockProvider(), nil
 	}
 

--- a/oracle/provider/binance.go
+++ b/oracle/provider/binance.go
@@ -144,15 +144,16 @@ func NewBinanceProvider(
 }
 
 func (p *BinanceProvider) getSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {
-	subscriptionMsgs := make([]interface{}, 0, len(p.subscribedPairs)*2)
-	for _, cp := range cps {
-		binanceTickerPair := currencyPairToBinanceTickerPair(cp)
-		subscriptionMsgs = append(subscriptionMsgs, newBinanceSubscriptionMsg(binanceTickerPair))
-
-		binanceCandlePair := currencyPairToBinanceCandlePair(cp)
-		subscriptionMsgs = append(subscriptionMsgs, newBinanceSubscriptionMsg(binanceCandlePair))
+	msg := BinanceSubscriptionMsg{
+		Method: "SUBSCRIBE",
+		Params: make([]string, len(cps) * 2),
+		ID:     1,
 	}
-	return subscriptionMsgs
+	for i, cp := range cps {
+		msg.Params[i * 2] = strings.ToLower(cp.String()) + "@ticker"
+		msg.Params[i * 2 + 1] = strings.ToLower(cp.String()) + "@kline_1m"
+	}
+	return []interface{}{msg}
 }
 
 // SubscribeCurrencyPairs sends the new subscription messages to the websocket
@@ -334,25 +335,4 @@ func (p *BinanceProvider) GetAvailablePairs() (map[string]struct{}, error) {
 	}
 
 	return availablePairs, nil
-}
-
-// currencyPairToBinanceTickerPair receives a currency pair and return binance
-// ticker symbol atomusdt@ticker.
-func currencyPairToBinanceTickerPair(cp types.CurrencyPair) string {
-	return strings.ToLower(cp.String() + "@ticker")
-}
-
-// currencyPairToBinanceCandlePair receives a currency pair and return binance
-// candle symbol atomusdt@kline_1m.
-func currencyPairToBinanceCandlePair(cp types.CurrencyPair) string {
-	return strings.ToLower(cp.String() + "@kline_1m")
-}
-
-// newBinanceSubscriptionMsg returns a new subscription Msg.
-func newBinanceSubscriptionMsg(params ...string) BinanceSubscriptionMsg {
-	return BinanceSubscriptionMsg{
-		Method: "SUBSCRIBE",
-		Params: params,
-		ID:     1,
-	}
 }

--- a/oracle/provider/binance.go
+++ b/oracle/provider/binance.go
@@ -8,21 +8,20 @@ import (
 	"net/url"
 	"strings"
 	"sync"
-	"time"
 
-	"price-feeder/config"
 	"price-feeder/oracle/types"
 
-	"github.com/cosmos/cosmos-sdk/telemetry"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
 )
 
 const (
-	binanceWSHost   = "stream.binance.com:9443"
-	binanceWSPath   = "/ws/umeestream"
-	binanceRestHost = "https://api1.binance.com"
-	binanceRestPath = "/api/v3/ticker/price"
+	binanceWSHost     = "stream.binance.com:9443"
+	binanceUSWSHost   = "stream.binance.us:9443"
+	binanceWSPath     = "/ws/umeestream"
+	binanceRestHost   = "https://api1.binance.com"
+	binanceRestUSHost = "https://api.binance.us"
+	binanceRestPath   = "/api/v3/ticker/price"
 )
 
 var _ Provider = (*BinanceProvider)(nil)
@@ -34,11 +33,10 @@ type (
 	// REF: https://binance-docs.github.io/apidocs/spot/en/#individual-symbol-mini-ticker-stream
 	// REF: https://binance-docs.github.io/apidocs/spot/en/#kline-candlestick-streams
 	BinanceProvider struct {
-		wsURL           url.URL
-		wsClient        *websocket.Conn
+		wsc             *WebsocketController
 		logger          zerolog.Logger
 		mtx             sync.RWMutex
-		endpoints       config.ProviderEndpoint
+		endpoints       Endpoint
 		tickers         map[string]BinanceTicker      // Symbol => BinanceTicker
 		candles         map[string][]BinanceCandle    // Symbol => BinanceCandle
 		subscribedPairs map[string]types.CurrencyPair // Symbol => types.CurrencyPair
@@ -76,6 +74,12 @@ type (
 		ID     uint16   `json:"id"`     // identify messages going back and forth
 	}
 
+	// BinanceSubscriptionResp the response structure for a binance subscription response
+	BinanceSubscriptionResp struct {
+		Result string `json:"result"`
+		ID     uint16 `json:"id"`
+	}
+
 	// BinancePairSummary defines the response structure for a Binance pair
 	// summary.
 	BinancePairSummary struct {
@@ -86,14 +90,23 @@ type (
 func NewBinanceProvider(
 	ctx context.Context,
 	logger zerolog.Logger,
-	endpoints config.ProviderEndpoint,
+	endpoints Endpoint,
+	binanceUS bool,
 	pairs ...types.CurrencyPair,
 ) (*BinanceProvider, error) {
-	if (endpoints.Name) != config.ProviderBinance {
-		endpoints = config.ProviderEndpoint{
-			Name:      config.ProviderBinance,
-			Rest:      binanceRestHost,
-			Websocket: binanceWSHost,
+	if (endpoints.Name) != ProviderBinance {
+		if !binanceUS {
+			endpoints = Endpoint{
+				Name:      ProviderBinance,
+				Rest:      binanceRestHost,
+				Websocket: binanceWSHost,
+			}
+		} else {
+			endpoints = Endpoint{
+				Name:      ProviderBinanceUS,
+				Rest:      binanceRestUSHost,
+				Websocket: binanceUSWSHost,
+			}
 		}
 	}
 
@@ -103,33 +116,69 @@ func NewBinanceProvider(
 		Path:   binanceWSPath,
 	}
 
-	wsConn, _, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("error connecting to Binance websocket: %w", err)
-	}
+	binanceLogger := logger.With().Str("provider", string(ProviderBinance)).Logger()
 
 	provider := &BinanceProvider{
-		wsURL:           wsURL,
-		wsClient:        wsConn,
-		logger:          logger.With().Str("provider", "binance").Logger(),
+		logger:          binanceLogger,
 		endpoints:       endpoints,
 		tickers:         map[string]BinanceTicker{},
 		candles:         map[string][]BinanceCandle{},
 		subscribedPairs: map[string]types.CurrencyPair{},
 	}
 
-	if err := provider.SubscribeCurrencyPairs(pairs...); err != nil {
-		return nil, err
-	}
+	provider.setSubscribedPairs(pairs...)
 
-	go provider.handleWebSocketMsgs(ctx)
+	provider.wsc = NewWebsocketController(
+		ctx,
+		ProviderBinance,
+		wsURL,
+		provider.getSubscriptionMsgs(pairs...),
+		provider.messageReceived,
+		disabledPingDuration,
+		websocket.PingMessage,
+		binanceLogger,
+	)
+	go provider.wsc.Start()
 
 	return provider, nil
 }
 
+func (p *BinanceProvider) getSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {
+	subscriptionMsgs := make([]interface{}, 0, len(p.subscribedPairs)*2)
+	for _, cp := range cps {
+		binanceTickerPair := currencyPairToBinanceTickerPair(cp)
+		subscriptionMsgs = append(subscriptionMsgs, newBinanceSubscriptionMsg(binanceTickerPair))
+
+		binanceCandlePair := currencyPairToBinanceCandlePair(cp)
+		subscriptionMsgs = append(subscriptionMsgs, newBinanceSubscriptionMsg(binanceCandlePair))
+	}
+	return subscriptionMsgs
+}
+
+// SubscribeCurrencyPairs sends the new subscription messages to the websocket
+// and adds them to the providers subscribedPairs array
+func (p *BinanceProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	newPairs := []types.CurrencyPair{}
+	for _, cp := range cps {
+		if _, ok := p.subscribedPairs[cp.String()]; !ok {
+			newPairs = append(newPairs, cp)
+		}
+	}
+
+	newSubscriptionMsgs := p.getSubscriptionMsgs(newPairs...)
+	if err := p.wsc.AddSubscriptionMsgs(newSubscriptionMsgs); err != nil {
+		return err
+	}
+	p.setSubscribedPairs(newPairs...)
+	return nil
+}
+
 // GetTickerPrices returns the tickerPrices based on the provided pairs.
-func (p *BinanceProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]TickerPrice, error) {
-	tickerPrices := make(map[string]TickerPrice, len(pairs))
+func (p *BinanceProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
+	tickerPrices := make(map[string]types.TickerPrice, len(pairs))
 
 	for _, cp := range pairs {
 		key := cp.String()
@@ -144,8 +193,8 @@ func (p *BinanceProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[stri
 }
 
 // GetCandlePrices returns the candlePrices based on the provided pairs.
-func (p *BinanceProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]CandlePrice, error) {
-	candlePrices := make(map[string][]CandlePrice, len(pairs))
+func (p *BinanceProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]types.CandlePrice, error) {
+	candlePrices := make(map[string][]types.CandlePrice, len(pairs))
 
 	for _, cp := range pairs {
 		key := cp.String()
@@ -159,85 +208,32 @@ func (p *BinanceProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[stri
 	return candlePrices, nil
 }
 
-// SubscribeCurrencyPairs subscribe all currency pairs into ticker and candle channels.
-func (p *BinanceProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
-	if len(cps) == 0 {
-		return fmt.Errorf("currency pairs is empty")
-	}
-
-	if err := p.subscribeChannels(cps...); err != nil {
-		return err
-	}
-
-	p.setSubscribedPairs(cps...)
-	return nil
-}
-
-// subscribeChannels subscribe to the ticker and candle channels for all currency pairs.
-func (p *BinanceProvider) subscribeChannels(cps ...types.CurrencyPair) error {
-	if err := p.subscribeTickers(cps...); err != nil {
-		return err
-	}
-
-	return p.subscribeCandles(cps...)
-}
-
-// subscribeTickers subscribe to the ticker channel for all currency pairs.
-func (p *BinanceProvider) subscribeTickers(cps ...types.CurrencyPair) error {
-	pairs := make([]string, len(cps))
-
-	for i, cp := range cps {
-		pairs[i] = currencyPairToBinanceTickerPair(cp)
-	}
-
-	return p.subscribePairs(pairs...)
-}
-
-// subscribeCandles subscribe to the candle channel for all currency pairs.
-func (p *BinanceProvider) subscribeCandles(cps ...types.CurrencyPair) error {
-	pairs := make([]string, len(cps))
-
-	for i, cp := range cps {
-		pairs[i] = currencyPairToBinanceCandlePair(cp)
-	}
-
-	return p.subscribePairs(pairs...)
-}
-
-// subscribedPairsToSlice returns the map of subscribed pairs as a slice.
-func (p *BinanceProvider) subscribedPairsToSlice() []types.CurrencyPair {
-	p.mtx.RLock()
-	defer p.mtx.RUnlock()
-
-	return types.MapPairsToSlice(p.subscribedPairs)
-}
-
-func (p *BinanceProvider) getTickerPrice(key string) (TickerPrice, error) {
+func (p *BinanceProvider) getTickerPrice(key string) (types.TickerPrice, error) {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
 	ticker, ok := p.tickers[key]
 	if !ok {
-		return TickerPrice{}, fmt.Errorf("binance provider failed to get ticker price for %s", key)
+		return types.TickerPrice{}, fmt.Errorf("binance failed to get ticker price for %s", key)
 	}
 
 	return ticker.toTickerPrice()
 }
 
-func (p *BinanceProvider) getCandlePrices(key string) ([]CandlePrice, error) {
+func (p *BinanceProvider) getCandlePrices(key string) ([]types.CandlePrice, error) {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
 	candles, ok := p.candles[key]
 	if !ok {
-		return []CandlePrice{}, fmt.Errorf("failed to get candle prices for %s", key)
+		return []types.CandlePrice{}, fmt.Errorf("binance failed to get candle prices for %s", key)
 	}
 
-	candleList := []CandlePrice{}
+	candleList := []types.CandlePrice{}
 	for _, candle := range candles {
 		cp, err := candle.toCandlePrice()
 		if err != nil {
-			return []CandlePrice{}, err
+			return []types.CandlePrice{}, err
 		}
 		candleList = append(candleList, cp)
 	}
@@ -245,44 +241,31 @@ func (p *BinanceProvider) getCandlePrices(key string) ([]CandlePrice, error) {
 }
 
 func (p *BinanceProvider) messageReceived(messageType int, bz []byte) {
-	if messageType != websocket.TextMessage {
-		return
-	}
-
 	var (
-		tickerResp BinanceTicker
-		tickerErr  error
-		candleResp BinanceCandle
-		candleErr  error
+		tickerResp       BinanceTicker
+		tickerErr        error
+		candleResp       BinanceCandle
+		candleErr        error
+		subscribeResp    BinanceSubscriptionResp
+		subscribeRespErr error
 	)
 
 	tickerErr = json.Unmarshal(bz, &tickerResp)
 	if len(tickerResp.LastPrice) != 0 {
 		p.setTickerPair(tickerResp)
-		telemetry.IncrCounter(
-			1,
-			"websocket",
-			"message",
-			"type",
-			"ticker",
-			"provider",
-			config.ProviderBinance,
-		)
+		telemetryWebsocketMessage(ProviderBinance, MessageTypeTicker)
 		return
 	}
 
 	candleErr = json.Unmarshal(bz, &candleResp)
 	if len(candleResp.Metadata.Close) != 0 {
 		p.setCandlePair(candleResp)
-		telemetry.IncrCounter(
-			1,
-			"websocket",
-			"message",
-			"type",
-			"candle",
-			"provider",
-			config.ProviderBinance,
-		)
+		telemetryWebsocketMessage(ProviderBinance, MessageTypeCandle)
+		return
+	}
+
+	subscribeRespErr = json.Unmarshal(bz, &subscribeResp)
+	if subscribeResp.ID == 1 {
 		return
 	}
 
@@ -290,6 +273,7 @@ func (p *BinanceProvider) messageReceived(messageType int, bz []byte) {
 		Int("length", len(bz)).
 		AnErr("ticker", tickerErr).
 		AnErr("candle", candleErr).
+		AnErr("subscribeResp", subscribeRespErr).
 		Msg("Error on receive message")
 }
 
@@ -314,108 +298,20 @@ func (p *BinanceProvider) setCandlePair(candle BinanceCandle) {
 	p.candles[candle.Symbol] = candleList
 }
 
-func (ticker BinanceTicker) toTickerPrice() (TickerPrice, error) {
-	return newTickerPrice("Binance", ticker.Symbol, ticker.LastPrice, ticker.Volume)
+func (ticker BinanceTicker) toTickerPrice() (types.TickerPrice, error) {
+	return types.NewTickerPrice(string(ProviderBinance), ticker.Symbol, ticker.LastPrice, ticker.Volume)
 }
 
-func (candle BinanceCandle) toCandlePrice() (CandlePrice, error) {
-	return newCandlePrice("Binance", candle.Symbol, candle.Metadata.Close, candle.Metadata.Volume,
+func (candle BinanceCandle) toCandlePrice() (types.CandlePrice, error) {
+	return types.NewCandlePrice(string(ProviderBinance), candle.Symbol, candle.Metadata.Close, candle.Metadata.Volume,
 		candle.Metadata.TimeStamp)
-}
-
-func (p *BinanceProvider) handleWebSocketMsgs(ctx context.Context) {
-	reconnectTicker := time.NewTicker(defaultMaxConnectionTime)
-	defer reconnectTicker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(defaultReadNewWSMessage):
-			messageType, bz, err := p.wsClient.ReadMessage()
-			if err != nil {
-				// if some error occurs continue to try to read the next message.
-				p.logger.Err(err).Msg("could not read message")
-				continue
-			}
-
-			if len(bz) == 0 {
-				continue
-			}
-
-			p.messageReceived(messageType, bz)
-
-		case <-reconnectTicker.C:
-			if err := p.reconnect(); err != nil {
-				p.logger.Err(err).Msg("error reconnecting")
-				p.keepReconnecting()
-			}
-		}
-	}
-}
-
-// reconnect closes the last WS connection then create a new one and subscribe to
-// all subscribed pairs in the ticker and candle pais. A single connection to
-// stream.binance.com is only valid for 24 hours; expect to be disconnected at the
-// 24 hour mark. The websocket server will send a ping frame every 3 minutes. If
-// the websocket server does not receive a pong frame back from the connection
-// within a 10 minute period, the connection will be disconnected.
-func (p *BinanceProvider) reconnect() error {
-	p.wsClient.Close()
-
-	p.logger.Debug().Msg("reconnecting websocket")
-	wsConn, _, err := websocket.DefaultDialer.Dial(p.wsURL.String(), nil)
-	if err != nil {
-		return fmt.Errorf("error reconnect to binance websocket: %w", err)
-	}
-	p.wsClient = wsConn
-
-	currencyPairs := p.subscribedPairsToSlice()
-
-	telemetry.IncrCounter(
-		1,
-		"websocket",
-		"reconnect",
-		"provider",
-		config.ProviderBinance,
-	)
-	return p.subscribeChannels(currencyPairs...)
-}
-
-// keepReconnecting keeps trying to reconnect if an error occurs in reconnect.
-func (p *BinanceProvider) keepReconnecting() {
-	reconnectTicker := time.NewTicker(defaultReconnectTime)
-	defer reconnectTicker.Stop()
-	connectionTries := 1
-
-	for time := range reconnectTicker.C {
-		if err := p.reconnect(); err != nil {
-			p.logger.Err(err).Msgf("attempted to reconnect %d times at %s", connectionTries, time.String())
-			connectionTries++
-			continue
-		}
-
-		if connectionTries > maxReconnectionTries {
-			p.logger.Warn().Msgf("failed to reconnect %d times", connectionTries)
-		}
-		return
-	}
 }
 
 // setSubscribedPairs sets N currency pairs to the map of subscribed pairs.
 func (p *BinanceProvider) setSubscribedPairs(cps ...types.CurrencyPair) {
-	p.mtx.Lock()
-	defer p.mtx.Unlock()
-
 	for _, cp := range cps {
 		p.subscribedPairs[cp.String()] = cp
 	}
-}
-
-// subscribePairs write the subscription msg to the provider.
-func (p *BinanceProvider) subscribePairs(pairs ...string) error {
-	subsMsg := newBinanceSubscriptionMsg(pairs...)
-	return p.wsClient.WriteJSON(subsMsg)
 }
 
 // GetAvailablePairs returns all pairs to which the provider can subscribe.

--- a/oracle/provider/binance_test.go
+++ b/oracle/provider/binance_test.go
@@ -79,12 +79,6 @@ func TestBinanceProvider_GetTickerPrices(t *testing.T) {
 	})
 }
 
-func TestBinanceCurrencyPairToBinancePair(t *testing.T) {
-	cp := types.CurrencyPair{Base: "ATOM", Quote: "USDT"}
-	binanceSymbol := currencyPairToBinanceTickerPair(cp)
-	require.Equal(t, binanceSymbol, "atomusdt@ticker")
-}
-
 func TestBinanceProvider_getSubscriptionMsgs(t *testing.T) {
 	provider := &BinanceProvider{
 		subscribedPairs: map[string]types.CurrencyPair{},
@@ -96,8 +90,5 @@ func TestBinanceProvider_getSubscriptionMsgs(t *testing.T) {
 	subMsgs := provider.getSubscriptionMsgs(cps...)
 
 	msg, _ := json.Marshal(subMsgs[0])
-	require.Equal(t, "{\"method\":\"SUBSCRIBE\",\"params\":[\"atomusdt@ticker\"],\"id\":1}", string(msg))
-
-	msg, _ = json.Marshal(subMsgs[1])
-	require.Equal(t, "{\"method\":\"SUBSCRIBE\",\"params\":[\"atomusdt@kline_1m\"],\"id\":1}", string(msg))
+	require.Equal(t, "{\"method\":\"SUBSCRIBE\",\"params\":[\"atomusdt@ticker\",\"atomusdt@kline_1m\"],\"id\":1}", string(msg))
 }

--- a/oracle/provider/bitget.go
+++ b/oracle/provider/bitget.go
@@ -1,0 +1,428 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+
+	"price-feeder/oracle/types"
+
+	"github.com/gorilla/websocket"
+	"github.com/rs/zerolog"
+)
+
+const (
+	bitgetWSHost        = "ws.bitget.com"
+	bitgetWSPath        = "/spot/v1/stream"
+	bitgetReconnectTime = time.Minute * 2
+	bitgetRestHost      = "https://api.bitget.com"
+	bitgetRestPath      = "/api/spot/v1/public/products"
+	tickerChannel       = "ticker"
+	candleChannel       = "candle5m"
+	instType            = "SP"
+)
+
+var _ Provider = (*BitgetProvider)(nil)
+
+type (
+	// BitgetProvider defines an Oracle provider implemented by the Bitget public
+	// API.
+	//
+	// REF: https://bitgetlimited.github.io/apidoc/en/spot/#tickers-channel
+	// REF: https://bitgetlimited.github.io/apidoc/en/spot/#candlesticks-channel
+	BitgetProvider struct {
+		wsc             *WebsocketController
+		logger          zerolog.Logger
+		mtx             sync.RWMutex
+		endpoints       Endpoint
+		tickers         map[string]BitgetTicker       // Symbol => BitgetTicker
+		candles         map[string][]BitgetCandle     // Symbol => BitgetCandle
+		subscribedPairs map[string]types.CurrencyPair // Symbol => types.CurrencyPair
+	}
+
+	// BitgetSubscriptionMsg Msg to subscribe all at once.
+	BitgetSubscriptionMsg struct {
+		Operation string                  `json:"op"`   // Operation (e.x. "subscribe")
+		Args      []BitgetSubscriptionArg `json:"args"` // Arguments to subscribe to
+	}
+	BitgetSubscriptionArg struct {
+		InstType string `json:"instType"` // Instrument type (e.g. "sp")
+		Channel  string `json:"channel"`  // Channel (e.x. "ticker" / "candle5m")
+		InstID   string `json:"instId"`   // Instrument ID (e.x. BTCUSDT)
+	}
+
+	// BitgetErrResponse is the structure for bitget subscription errors.
+	BitgetErrResponse struct {
+		Event string `json:"event"` // e.x. "error"
+		Code  uint64 `json:"code"`  // e.x. 30003 for invalid op
+		Msg   string `json:"msg"`   // e.x. "INVALID op"
+	}
+	// BitgetSubscriptionResponse is the structure for bitget subscription confirmations.
+	BitgetSubscriptionResponse struct {
+		Event string                `json:"event"` // e.x. "subscribe"
+		Arg   BitgetSubscriptionArg `json:"arg"`   // subscription event argument
+	}
+
+	// BitgetTickerResponse is the structure for bitget ticker messages.
+	BitgetTicker struct {
+		Action string                `json:"action"` // e.x. "snapshot"
+		Arg    BitgetSubscriptionArg `json:"arg"`    // subscription event argument
+		Data   []BitgetTickerData    `json:"data"`   // ticker data
+	}
+	BitgetTickerData struct {
+		InstID string `json:"instId"`     // e.x. BTCUSD
+		Price  string `json:"last"`       // last price e.x. "12.3907"
+		Volume string `json:"baseVolume"` // volume in base asset (e.x. "112247.9173")
+	}
+
+	// BitgetCandleResponse is the response structure for the bitget ticker message.
+	BitgetCandleResponse struct {
+		Action string                `json:"action"` // e.x. "snapshot"
+		Arg    BitgetSubscriptionArg `json:"arg"`    // subscription event argument
+		Data   [][]string            `json:"data"`   // candle data in an array at data[0].
+	}
+	BitgetCandle struct {
+		Arg       BitgetSubscriptionArg // subscription event argument
+		TimeStamp int64                 // unix timestamp in milliseconds e.x. 1597026383085
+		Close     string                // Most recent price e.x. "8533.02"
+		Volume    string                // volume e.x. "45247"
+	}
+
+	// BitgetPairsSummary defines the response structure for a Bitget pairs
+	// summary.
+	BitgetPairsSummary struct {
+		RespCode string           `json:"code"`
+		Data     []BitgetPairData `json:"data"`
+	}
+	BitgetPairData struct {
+		Base  string `json:"baseCoin"`
+		Quote string `json:"quoteCoin"`
+	}
+)
+
+// NewBitgetProvider returns a new Bitget provider with the WS connection
+// and msg handler.
+func NewBitgetProvider(
+	ctx context.Context,
+	logger zerolog.Logger,
+	endpoints Endpoint,
+	pairs ...types.CurrencyPair,
+) (*BitgetProvider, error) {
+	if endpoints.Name != ProviderBitget {
+		endpoints = Endpoint{
+			Name:      ProviderBitget,
+			Rest:      bitgetRestHost,
+			Websocket: bitgetWSHost,
+		}
+	}
+
+	wsURL := url.URL{
+		Scheme: "wss",
+		Host:   endpoints.Websocket,
+		Path:   bitgetWSPath,
+	}
+
+	bitgetLogger := logger.With().Str("provider", string(ProviderBitget)).Logger()
+
+	provider := &BitgetProvider{
+		logger:          bitgetLogger,
+		endpoints:       endpoints,
+		tickers:         map[string]BitgetTicker{},
+		candles:         map[string][]BitgetCandle{},
+		subscribedPairs: map[string]types.CurrencyPair{},
+	}
+
+	provider.setSubscribedPairs(pairs...)
+
+	provider.wsc = NewWebsocketController(
+		ctx,
+		ProviderBitget,
+		wsURL,
+		provider.getSubscriptionMsgs(pairs...),
+		provider.messageReceived,
+		defaultPingDuration,
+		websocket.TextMessage,
+		bitgetLogger,
+	)
+	go provider.wsc.Start()
+
+	return provider, nil
+}
+
+func (p *BitgetProvider) getSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {
+	subscriptionMsgs := make([]interface{}, 0, 1)
+	bitgetTickerSubscriptionMsg := newBitgetTickerSubscriptionMsg(cps)
+	subscriptionMsgs = append(subscriptionMsgs, bitgetTickerSubscriptionMsg)
+
+	return subscriptionMsgs
+}
+
+// SubscribeCurrencyPairs sends the new subscription messages to the websocket
+// and adds them to the providers subscribedPairs array
+func (p *BitgetProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	newPairs := []types.CurrencyPair{}
+	for _, cp := range cps {
+		if _, ok := p.subscribedPairs[cp.String()]; !ok {
+			newPairs = append(newPairs, cp)
+		}
+	}
+
+	newSubscriptionMsgs := p.getSubscriptionMsgs(newPairs...)
+	if err := p.wsc.AddSubscriptionMsgs(newSubscriptionMsgs); err != nil {
+		return err
+	}
+	p.setSubscribedPairs(newPairs...)
+	return nil
+}
+
+// GetTickerPrices returns the tickerPrices based on the saved map.
+func (p *BitgetProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
+	tickerPrices := make(map[string]types.TickerPrice, len(pairs))
+
+	for _, cp := range pairs {
+		price, err := p.getTickerPrice(cp)
+		if err != nil {
+			return nil, err
+		}
+		tickerPrices[cp.String()] = price
+	}
+
+	return tickerPrices, nil
+}
+
+// GetTickerPrices returns the tickerPrices based on the saved map.
+func (p *BitgetProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]types.CandlePrice, error) {
+	candlePrices := make(map[string][]types.CandlePrice, len(pairs))
+
+	for _, cp := range pairs {
+		price, err := p.getCandlePrices(cp)
+		if err != nil {
+			return nil, err
+		}
+		candlePrices[cp.String()] = price
+	}
+
+	return candlePrices, nil
+}
+
+// messageReceived handles the received data from the Bitget websocket.
+func (p *BitgetProvider) messageReceived(messageType int, bz []byte) {
+	var (
+		tickerResp           BitgetTicker
+		tickerErr            error
+		candleResp           BitgetCandleResponse
+		candleErr            error
+		errResponse          BitgetErrResponse
+		subscriptionResponse BitgetSubscriptionResponse
+	)
+
+	err := json.Unmarshal(bz, &errResponse)
+	if err == nil && errResponse.Code != 0 {
+		p.logger.Error().
+			Int("length", len(bz)).
+			Str("msg", errResponse.Msg).
+			Str("body", string(bz)).
+			Msg("Error on receive bitget message")
+		return
+	}
+
+	err = json.Unmarshal(bz, &subscriptionResponse)
+	if err == nil && subscriptionResponse.Event == "subscribe" {
+		p.logger.Debug().
+			Str("InstID", subscriptionResponse.Arg.InstID).
+			Str("Channel", subscriptionResponse.Arg.Channel).
+			Str("InstType", subscriptionResponse.Arg.InstType).
+			Msg("Bitget subscription confirmed")
+		return
+	}
+
+	tickerErr = json.Unmarshal(bz, &tickerResp)
+	if tickerResp.Arg.Channel == tickerChannel {
+		p.setTickerPair(tickerResp)
+		telemetryWebsocketMessage(ProviderBitget, MessageTypeTicker)
+		return
+	}
+
+	candleErr = json.Unmarshal(bz, &candleResp)
+	if candleResp.Arg.Channel == candleChannel {
+		candle, err := candleResp.ToBitgetCandle()
+		if err != nil {
+			p.logger.Error().
+				Int("length", len(bz)).
+				AnErr("candle", err).
+				Msg("Unable to parse bitget candle")
+		}
+		p.setCandlePair(candle)
+		telemetryWebsocketMessage(ProviderBitget, MessageTypeCandle)
+		return
+	}
+
+	p.logger.Error().
+		Int("length", len(bz)).
+		AnErr("ticker", tickerErr).
+		AnErr("candle", candleErr).
+		Msg("Error on receive message")
+}
+
+// ToBitgetCandle turns a BitgetCandleResponse into a more-readable
+// BitgetCandle. The Close and Volume responses are at the [0][4] and
+// [0][5] indexes respectively.
+// Ref: https://bitgetlimited.github.io/apidoc/en/spot/#candlesticks-channel
+func (bcr BitgetCandleResponse) ToBitgetCandle() (BitgetCandle, error) {
+	if len(bcr.Data) < 1 || len(bcr.Data[0]) < 6 {
+		return BitgetCandle{}, fmt.Errorf("invalid candle response")
+	}
+
+	ts, err := strconv.ParseInt(bcr.Data[0][0], 10, 64)
+	if err != nil {
+		return BitgetCandle{}, err
+	}
+
+	return BitgetCandle{
+		Arg:       bcr.Arg,
+		TimeStamp: ts,
+		Close:     bcr.Data[0][4],
+		Volume:    bcr.Data[0][5],
+	}, nil
+}
+
+func (p *BitgetProvider) setTickerPair(ticker BitgetTicker) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	p.tickers[ticker.Arg.InstID] = ticker
+}
+
+func (p *BitgetProvider) setCandlePair(candle BitgetCandle) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	staleTime := PastUnixTime(providerCandlePeriod)
+	candleList := []BitgetCandle{}
+	candleList = append(candleList, candle)
+
+	for _, c := range p.candles[candle.Arg.InstID] {
+		if staleTime < c.TimeStamp {
+			candleList = append(candleList, c)
+		}
+	}
+	p.candles[candle.Arg.InstID] = candleList
+}
+
+func (p *BitgetProvider) getTickerPrice(cp types.CurrencyPair) (types.TickerPrice, error) {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	ticker, ok := p.tickers[cp.String()]
+	if !ok {
+		return types.TickerPrice{}, fmt.Errorf("bitget failed to get ticker price for %s", cp.String())
+	}
+
+	return ticker.toTickerPrice()
+}
+
+func (p *BitgetProvider) getCandlePrices(cp types.CurrencyPair) ([]types.CandlePrice, error) {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	candles, ok := p.candles[cp.String()]
+	if !ok {
+		return []types.CandlePrice{}, fmt.Errorf("failed to get candles price for %s", cp.String())
+	}
+
+	candleList := []types.CandlePrice{}
+	for _, candle := range candles {
+		cp, err := candle.toCandlePrice()
+		if err != nil {
+			return []types.CandlePrice{}, err
+		}
+		candleList = append(candleList, cp)
+	}
+	return candleList, nil
+}
+
+// setSubscribedPairs sets N currency pairs to the map of subscribed pairs.
+func (p *BitgetProvider) setSubscribedPairs(cps ...types.CurrencyPair) {
+	for _, cp := range cps {
+		p.subscribedPairs[cp.String()] = cp
+	}
+}
+
+// GetAvailablePairs returns all pairs to which the provider can subscribe.
+func (p *BitgetProvider) GetAvailablePairs() (map[string]struct{}, error) {
+	resp, err := http.Get(p.endpoints.Rest + bitgetRestPath)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var pairsSummary BitgetPairsSummary
+	if err := json.NewDecoder(resp.Body).Decode(&pairsSummary); err != nil {
+		return nil, err
+	}
+	if pairsSummary.RespCode != "00000" {
+		return nil, fmt.Errorf("unable to get bitget available pairs")
+	}
+
+	availablePairs := make(map[string]struct{}, len(pairsSummary.Data))
+	for _, pair := range pairsSummary.Data {
+		cp := types.CurrencyPair{
+			Base:  pair.Base,
+			Quote: pair.Quote,
+		}
+		availablePairs[cp.String()] = struct{}{}
+	}
+
+	return availablePairs, nil
+}
+
+// toTickerPrice converts current BitgetTicker to TickerPrice.
+func (ticker BitgetTicker) toTickerPrice() (types.TickerPrice, error) {
+	if len(ticker.Data) < 1 {
+		return types.TickerPrice{}, fmt.Errorf("ticker has no data")
+	}
+	return types.NewTickerPrice(
+		string(ProviderBitget),
+		ticker.Arg.InstID,
+		ticker.Data[0].Price,
+		ticker.Data[0].Volume,
+	)
+}
+
+func (candle BitgetCandle) toCandlePrice() (types.CandlePrice, error) {
+	return types.NewCandlePrice(
+		string(ProviderBitget),
+		candle.Arg.InstID,
+		candle.Close,
+		candle.Volume,
+		candle.TimeStamp,
+	)
+}
+
+// newBitgetTickerSubscriptionMsg returns a new ticker subscription Msg.
+func newBitgetTickerSubscriptionMsg(cps []types.CurrencyPair) BitgetSubscriptionMsg {
+	args := []BitgetSubscriptionArg{}
+	for _, cp := range cps {
+		args = append(args, BitgetSubscriptionArg{
+			InstType: instType,
+			Channel:  tickerChannel,
+			InstID:   cp.String(),
+		})
+		args = append(args, BitgetSubscriptionArg{
+			InstType: instType,
+			Channel:  candleChannel,
+			InstID:   cp.String(),
+		})
+	}
+
+	return BitgetSubscriptionMsg{
+		Operation: "subscribe",
+		Args:      args,
+	}
+}

--- a/oracle/provider/bitget_test.go
+++ b/oracle/provider/bitget_test.go
@@ -1,0 +1,182 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	"price-feeder/oracle/types"
+)
+
+func TestBitgetProvider_GetTickerPrices(t *testing.T) {
+	p, err := NewBitgetProvider(
+		context.TODO(),
+		zerolog.Nop(),
+		Endpoint{},
+		types.CurrencyPair{Base: "BTC", Quote: "USDT"},
+	)
+	require.NoError(t, err)
+
+	t.Run("valid_request_single_ticker", func(t *testing.T) {
+		lastPrice := "34.69000000"
+		volume := "2396974.02000000"
+		instId := "ATOMUSDT"
+
+		tickerMap := map[string]BitgetTicker{}
+		tickerMap[instId] = BitgetTicker{
+			Arg: BitgetSubscriptionArg{
+				Channel: "tickers",
+				InstID:  instId,
+			},
+			Data: []BitgetTickerData{
+				{
+					InstID: instId,
+					Price:  lastPrice,
+					Volume: volume,
+				},
+			},
+		}
+
+		p.tickers = tickerMap
+
+		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+		require.NoError(t, err)
+		require.Len(t, prices, 1)
+		require.Equal(t, sdk.MustNewDecFromStr(lastPrice), prices["ATOMUSDT"].Price)
+		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["ATOMUSDT"].Volume)
+	})
+
+	t.Run("valid_request_multi_ticker", func(t *testing.T) {
+		atomInstID := "ATOMUSDT"
+		atomLastPrice := "34.69000000"
+		lunaInstID := "LUNAUSDT"
+		lunaLastPrice := "41.35000000"
+		volume := "2396974.02000000"
+
+		tickerMap := map[string]BitgetTicker{}
+		tickerMap[atomInstID] = BitgetTicker{
+			Arg: BitgetSubscriptionArg{
+				Channel: "tickers",
+				InstID:  atomInstID,
+			},
+			Data: []BitgetTickerData{
+				{
+					InstID: atomInstID,
+					Price:  atomLastPrice,
+					Volume: volume,
+				},
+			},
+		}
+		tickerMap[lunaInstID] = BitgetTicker{
+			Arg: BitgetSubscriptionArg{
+				Channel: "tickers",
+				InstID:  lunaInstID,
+			},
+			Data: []BitgetTickerData{
+				{
+					InstID: lunaInstID,
+					Price:  lunaLastPrice,
+					Volume: volume,
+				},
+			},
+		}
+		p.tickers = tickerMap
+		prices, err := p.GetTickerPrices(
+			types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
+			types.CurrencyPair{Base: "LUNA", Quote: "USDT"},
+		)
+
+		require.NoError(t, err)
+		require.Len(t, prices, 2)
+		require.Equal(t, sdk.MustNewDecFromStr(atomLastPrice), prices["ATOMUSDT"].Price)
+		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["ATOMUSDT"].Volume)
+		require.Equal(t, sdk.MustNewDecFromStr(lunaLastPrice), prices["LUNAUSDT"].Price)
+		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["LUNAUSDT"].Volume)
+	})
+
+	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {
+		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
+		require.EqualError(t, err, "bitget failed to get ticker price for FOOBAR")
+		require.Nil(t, prices)
+	})
+}
+
+func TestBitgetProvider_GetCandlePrices(t *testing.T) {
+	p, err := NewBitgetProvider(
+		context.TODO(),
+		zerolog.Nop(),
+		Endpoint{},
+		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
+	)
+	require.NoError(t, err)
+
+	t.Run("valid_request_single_candle", func(t *testing.T) {
+		price := "34.689998626708984000"
+		volume := "2396974.000000000000000000"
+		timeStamp := int64(1000000)
+
+		candle := BitgetCandle{
+			TimeStamp: timeStamp,
+			Close:     price,
+			Volume:    volume,
+			Arg: BitgetSubscriptionArg{
+				Channel: "candle15m",
+				InstID:  "ATOMUSDT",
+			},
+		}
+
+		p.setCandlePair(candle)
+
+		prices, err := p.GetCandlePrices(types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+		require.NoError(t, err)
+		require.Len(t, prices, 1)
+		require.Equal(t, sdk.MustNewDecFromStr(price), prices["ATOMUSDT"][0].Price)
+		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["ATOMUSDT"][0].Volume)
+		require.Equal(t, timeStamp, prices["ATOMUSDT"][0].TimeStamp)
+	})
+
+	t.Run("invalid_request_invalid_candle", func(t *testing.T) {
+		prices, err := p.GetCandlePrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
+		require.EqualError(t, err, "failed to get candles price for FOOBAR")
+		require.Nil(t, prices)
+	})
+}
+
+func TestBitgetProvider_AvailablePairs(t *testing.T) {
+	p, err := NewBitgetProvider(
+		context.TODO(),
+		zerolog.Nop(),
+		Endpoint{},
+		types.CurrencyPair{},
+	)
+	require.NoError(t, err)
+
+	pairs, err := p.GetAvailablePairs()
+	require.NoError(t, err)
+
+	require.NotEmpty(t, pairs)
+}
+
+func TestBitgetProvider_NewSubscriptionMsg(t *testing.T) {
+	cps := []types.CurrencyPair{
+		{
+			Base: "ATOM", Quote: "USDT",
+		},
+		{
+			Base: "FOO", Quote: "BAR",
+		},
+	}
+	sub := newBitgetTickerSubscriptionMsg(cps)
+
+	require.Equal(t, len(sub.Args), 2*len(cps))
+	require.Equal(t, sub.Args[0].InstID, "ATOMUSDT")
+	require.Equal(t, sub.Args[0].Channel, "ticker")
+	require.Equal(t, sub.Args[1].InstID, "ATOMUSDT")
+	require.Equal(t, sub.Args[1].Channel, "candle5m")
+	require.Equal(t, sub.Args[2].InstID, "FOOBAR")
+	require.Equal(t, sub.Args[2].Channel, "ticker")
+	require.Equal(t, sub.Args[3].InstID, "FOOBAR")
+	require.Equal(t, sub.Args[3].Channel, "candle5m")
+}

--- a/oracle/provider/crypto.go
+++ b/oracle/provider/crypto.go
@@ -1,0 +1,428 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"price-feeder/oracle/types"
+
+	"github.com/gorilla/websocket"
+	"github.com/rs/zerolog"
+)
+
+const (
+	cryptoWSHost             = "stream.crypto.com"
+	cryptoWSPath             = "/v2/market"
+	cryptoReconnectTime      = time.Second * 30
+	cryptoRestHost           = "https://api.crypto.com"
+	cryptoRestPath           = "/v2/public/get-ticker"
+	cryptoTickerChannel      = "ticker"
+	cryptoCandleChannel      = "candlestick"
+	cryptoHeartbeatMethod    = "public/heartbeat"
+	cryptoHeartbeatReqMethod = "public/respond-heartbeat"
+	cryptoTickerMsgPrefix    = "ticker."
+	cryptoCandleMsgPrefix    = "candlestick.5m."
+)
+
+var _ Provider = (*CryptoProvider)(nil)
+
+type (
+	// CryptoProvider defines an Oracle provider implemented by the Crypto.com public
+	// API.
+	//
+	// REF: https://exchange-docs.crypto.com/spot/index.html#introduction
+	CryptoProvider struct {
+		wsc             *WebsocketController
+		logger          zerolog.Logger
+		mtx             sync.RWMutex
+		endpoints       Endpoint
+		tickers         map[string]types.TickerPrice   // Symbol => TickerPrice
+		candles         map[string][]types.CandlePrice // Symbol => CandlePrice
+		subscribedPairs map[string]types.CurrencyPair  // Symbol => types.CurrencyPair
+	}
+
+	CryptoTickerResponse struct {
+		Result CryptoTickerResult `json:"result"`
+	}
+	CryptoTickerResult struct {
+		InstrumentName string         `json:"instrument_name"` // ex.: ATOM_USDT
+		Channel        string         `json:"channel"`         // ex.: ticker
+		Data           []CryptoTicker `json:"data"`            // ticker data
+	}
+	CryptoTicker struct {
+		InstrumentName string `json:"i"` // Instrument Name, e.g. BTC_USDT, ETH_CRO, etc.
+		Volume         string `json:"v"` // The total 24h traded volume
+		LatestTrade    string `json:"a"` // The price of the latest trade, null if there weren't any trades
+	}
+
+	CryptoCandleResponse struct {
+		Result CryptoCandleResult `json:"result"`
+	}
+	CryptoCandleResult struct {
+		InstrumentName string         `json:"instrument_name"` // ex.: ATOM_USDT
+		Channel        string         `json:"channel"`         // ex.: candlestick
+		Data           []CryptoCandle `json:"data"`            // candlestick data
+	}
+	CryptoCandle struct {
+		Close     string `json:"c"` // Price at close
+		Volume    string `json:"v"` // Volume during interval
+		Timestamp int64  `json:"t"` // End time of candlestick (Unix timestamp)
+	}
+
+	CryptoSubscriptionMsg struct {
+		ID     int64                    `json:"id"`
+		Method string                   `json:"method"` // subscribe, unsubscribe
+		Params CryptoSubscriptionParams `json:"params"`
+		Nonce  int64                    `json:"nonce"` // Current timestamp (milliseconds since the Unix epoch)
+	}
+	CryptoSubscriptionParams struct {
+		Channels []string `json:"channels"` // Channels to be subscribed ex. ticker.ATOM_USDT
+	}
+
+	CryptoPairsSummary struct {
+		Result CryptoInstruments `json:"result"`
+	}
+	CryptoInstruments struct {
+		Data []CryptoTicker `json:"data"`
+	}
+
+	CryptoHeartbeatResponse struct {
+		ID     int64  `json:"id"`
+		Method string `json:"method"` // public/heartbeat
+	}
+	CryptoHeartbeatRequest struct {
+		ID     int64  `json:"id"`
+		Method string `json:"method"` // public/respond-heartbeat
+	}
+)
+
+func NewCryptoProvider(
+	ctx context.Context,
+	logger zerolog.Logger,
+	endpoints Endpoint,
+	pairs ...types.CurrencyPair,
+) (*CryptoProvider, error) {
+	if endpoints.Name != ProviderCrypto {
+		endpoints = Endpoint{
+			Name:      ProviderCrypto,
+			Rest:      cryptoRestHost,
+			Websocket: cryptoWSHost,
+		}
+	}
+
+	wsURL := url.URL{
+		Scheme: "wss",
+		Host:   endpoints.Websocket,
+		Path:   cryptoWSPath,
+	}
+
+	cryptoLogger := logger.With().Str("provider", "crypto").Logger()
+
+	provider := &CryptoProvider{
+		logger:          cryptoLogger,
+		endpoints:       endpoints,
+		tickers:         map[string]types.TickerPrice{},
+		candles:         map[string][]types.CandlePrice{},
+		subscribedPairs: map[string]types.CurrencyPair{},
+	}
+
+	provider.setSubscribedPairs(pairs...)
+
+	provider.wsc = NewWebsocketController(
+		ctx,
+		ProviderCrypto,
+		wsURL,
+		provider.getSubscriptionMsgs(pairs...),
+		provider.messageReceived,
+		disabledPingDuration,
+		websocket.PingMessage,
+		cryptoLogger,
+	)
+	go provider.wsc.Start()
+
+	return provider, nil
+}
+
+func (p *CryptoProvider) getSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {
+	subscriptionMsgs := make([]interface{}, 0, len(cps)*2)
+	for _, cp := range cps {
+		cryptoPair := currencyPairToCryptoPair(cp)
+		channel := cryptoTickerMsgPrefix + cryptoPair
+		msg := newCryptoSubscriptionMsg([]string{channel})
+		subscriptionMsgs = append(subscriptionMsgs, msg)
+
+		cryptoPair = currencyPairToCryptoPair(cp)
+		channel = cryptoCandleMsgPrefix + cryptoPair
+		msg = newCryptoSubscriptionMsg([]string{channel})
+		subscriptionMsgs = append(subscriptionMsgs, msg)
+	}
+	return subscriptionMsgs
+}
+
+// SubscribeCurrencyPairs sends the new subscription messages to the websocket
+// and adds them to the providers subscribedPairs array
+func (p *CryptoProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	newPairs := []types.CurrencyPair{}
+	for _, cp := range cps {
+		if _, ok := p.subscribedPairs[cp.String()]; !ok {
+			newPairs = append(newPairs, cp)
+		}
+	}
+
+	newSubscriptionMsgs := p.getSubscriptionMsgs(newPairs...)
+	if err := p.wsc.AddSubscriptionMsgs(newSubscriptionMsgs); err != nil {
+		return err
+	}
+	p.setSubscribedPairs(newPairs...)
+	return nil
+}
+
+// GetTickerPrices returns the tickerPrices based on the saved map.
+func (p *CryptoProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
+	tickerPrices := make(map[string]types.TickerPrice, len(pairs))
+
+	for _, cp := range pairs {
+		key := currencyPairToCryptoPair(cp)
+		price, err := p.getTickerPrice(key)
+		if err != nil {
+			return nil, err
+		}
+		tickerPrices[cp.String()] = price
+	}
+
+	return tickerPrices, nil
+}
+
+// GetCandlePrices returns the candlePrices based on the saved map
+func (p *CryptoProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]types.CandlePrice, error) {
+	candlePrices := make(map[string][]types.CandlePrice, len(pairs))
+
+	for _, cp := range pairs {
+		key := currencyPairToCryptoPair(cp)
+		prices, err := p.getCandlePrices(key)
+		if err != nil {
+			return nil, err
+		}
+		candlePrices[cp.String()] = prices
+	}
+
+	return candlePrices, nil
+}
+
+func (p *CryptoProvider) getTickerPrice(key string) (types.TickerPrice, error) {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	ticker, ok := p.tickers[key]
+	if !ok {
+		return types.TickerPrice{}, fmt.Errorf(
+			types.ErrTickerNotFound.Error(),
+			ProviderCrypto,
+			key,
+		)
+	}
+
+	return ticker, nil
+}
+
+func (p *CryptoProvider) getCandlePrices(key string) ([]types.CandlePrice, error) {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	candles, ok := p.candles[key]
+	if !ok {
+		return []types.CandlePrice{}, fmt.Errorf(
+			types.ErrCandleNotFound.Error(),
+			ProviderCrypto,
+			key,
+		)
+	}
+
+	candleList := []types.CandlePrice{}
+	candleList = append(candleList, candles...)
+
+	return candleList, nil
+}
+
+func (p *CryptoProvider) messageReceived(messageType int, bz []byte) {
+	if messageType != websocket.TextMessage {
+		return
+	}
+
+	var (
+		heartbeatResp CryptoHeartbeatResponse
+		heartbeatErr  error
+		tickerResp    CryptoTickerResponse
+		tickerErr     error
+		candleResp    CryptoCandleResponse
+		candleErr     error
+	)
+
+	// sometimes the message received is not a ticker or a candle response.
+	heartbeatErr = json.Unmarshal(bz, &heartbeatResp)
+	if heartbeatResp.Method == cryptoHeartbeatMethod {
+		p.pong(heartbeatResp)
+		return
+	}
+
+	tickerErr = json.Unmarshal(bz, &tickerResp)
+	if tickerResp.Result.Channel == cryptoTickerChannel {
+		for _, tickerPair := range tickerResp.Result.Data {
+			p.setTickerPair(
+				tickerResp.Result.InstrumentName,
+				tickerPair,
+			)
+			telemetryWebsocketMessage(ProviderCrypto, MessageTypeTicker)
+		}
+		return
+	}
+
+	candleErr = json.Unmarshal(bz, &candleResp)
+	if candleResp.Result.Channel == cryptoCandleChannel {
+		for _, candlePair := range candleResp.Result.Data {
+			p.setCandlePair(
+				candleResp.Result.InstrumentName,
+				candlePair,
+			)
+			telemetryWebsocketMessage(ProviderCrypto, MessageTypeCandle)
+		}
+		return
+	}
+
+	p.logger.Error().
+		Int("length", len(bz)).
+		AnErr("heartbeat", heartbeatErr).
+		AnErr("ticker", tickerErr).
+		AnErr("candle", candleErr).
+		Msg("Error on receive message")
+}
+
+// pong return a heartbeat message when a "ping" is received and reset the
+// recconnect ticker because the connection is alive. After connected to crypto.com's
+// Websocket server, the server will send heartbeat periodically (30s interval).
+// When client receives an heartbeat message, it must respond back with the
+// public/respond-heartbeat method, using the same matching id,
+// within 5 seconds, or the connection will break.
+func (p *CryptoProvider) pong(heartbeatResp CryptoHeartbeatResponse) {
+	heartbeatReq := CryptoHeartbeatRequest{
+		ID:     heartbeatResp.ID,
+		Method: cryptoHeartbeatReqMethod,
+	}
+
+	if err := p.wsc.SendJSON(heartbeatReq); err != nil {
+		p.logger.Err(err).Msg("could not send pong message back")
+	}
+}
+
+func (p *CryptoProvider) setTickerPair(symbol string, tickerPair CryptoTicker) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	tickerPrice, err := types.NewTickerPrice(
+		string(ProviderCrypto),
+		symbol,
+		tickerPair.LatestTrade,
+		tickerPair.Volume,
+	)
+	if err != nil {
+		p.logger.Warn().Err(err).Msg("crypto: failed to parse ticker")
+		return
+	}
+
+	p.tickers[symbol] = tickerPrice
+}
+
+func (p *CryptoProvider) setCandlePair(symbol string, candlePair CryptoCandle) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	candle, err := types.NewCandlePrice(
+		string(ProviderCrypto),
+		symbol,
+		candlePair.Close,
+		candlePair.Volume,
+		SecondsToMilli(candlePair.Timestamp),
+	)
+	if err != nil {
+		p.logger.Warn().Err(err).Msg("crypto: failed to parse candle")
+		return
+	}
+
+	staleTime := PastUnixTime(providerCandlePeriod)
+	candleList := []types.CandlePrice{}
+	candleList = append(candleList, candle)
+
+	for _, c := range p.candles[symbol] {
+		if staleTime < c.TimeStamp {
+			candleList = append(candleList, c)
+		}
+	}
+
+	p.candles[symbol] = candleList
+}
+
+// setSubscribedPairs sets N currency pairs to the map of subscribed pairs.
+func (p *CryptoProvider) setSubscribedPairs(cps ...types.CurrencyPair) {
+	for _, cp := range cps {
+		p.subscribedPairs[cp.String()] = cp
+	}
+}
+
+// GetAvailablePairs returns all pairs to which the provider can subscribe.
+// ex.: map["ATOMUSDT" => {}, "UMEEUSDC" => {}].
+func (p *CryptoProvider) GetAvailablePairs() (map[string]struct{}, error) {
+	resp, err := http.Get(p.endpoints.Rest + cryptoRestPath)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var pairsSummary CryptoPairsSummary
+	if err := json.NewDecoder(resp.Body).Decode(&pairsSummary); err != nil {
+		return nil, err
+	}
+
+	availablePairs := make(map[string]struct{}, len(pairsSummary.Result.Data))
+	for _, pair := range pairsSummary.Result.Data {
+		splitInstName := strings.Split(pair.InstrumentName, "_")
+		if len(splitInstName) != 2 {
+			continue
+		}
+
+		cp := types.CurrencyPair{
+			Base:  strings.ToUpper(splitInstName[0]),
+			Quote: strings.ToUpper(splitInstName[1]),
+		}
+
+		availablePairs[cp.String()] = struct{}{}
+	}
+
+	return availablePairs, nil
+}
+
+// currencyPairToCryptoPair receives a currency pair and return crypto
+// ticker symbol atomusdt@ticker.
+func currencyPairToCryptoPair(cp types.CurrencyPair) string {
+	return strings.ToUpper(cp.Base + "_" + cp.Quote)
+}
+
+// newCryptoSubscriptionMsg returns a new subscription Msg.
+func newCryptoSubscriptionMsg(channels []string) CryptoSubscriptionMsg {
+	return CryptoSubscriptionMsg{
+		ID:     1,
+		Method: "subscribe",
+		Params: CryptoSubscriptionParams{
+			Channels: channels,
+		},
+		Nonce: time.Now().UnixMilli(),
+	}
+}

--- a/oracle/provider/fin.go
+++ b/oracle/provider/fin.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"price-feeder/config"
 	"price-feeder/oracle/types"
 )
 
@@ -63,8 +62,8 @@ type (
 	}
 )
 
-func NewFinProvider(endpoint config.ProviderEndpoint) *FinProvider {
-	if endpoint.Name == config.ProviderFin {
+func NewFinProvider(endpoint Endpoint) *FinProvider {
+	if endpoint.Name == ProviderFin {
 		return &FinProvider{
 			baseURL: endpoint.Rest,
 			client:  newDefaultHTTPClient(),
@@ -76,7 +75,7 @@ func NewFinProvider(endpoint config.ProviderEndpoint) *FinProvider {
 	}
 }
 
-func (p FinProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]TickerPrice, error) {
+func (p FinProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
 	path := fmt.Sprintf("%s%s", p.baseURL, finTickersEndpoint)
 	tickerResponse, err := p.client.Get(path)
 	if err != nil {
@@ -96,7 +95,7 @@ func (p FinProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]Ti
 	for _, pair := range pairs {
 		tickerSymbolPairs[pair.Base+"_"+pair.Quote] = pair
 	}
-	tickerPrices := make(map[string]TickerPrice, len(pairs))
+	tickerPrices := make(map[string]types.TickerPrice, len(pairs))
 	for _, ticker := range tickers.Tickers {
 		pair, ok := tickerSymbolPairs[strings.ToUpper(ticker.Symbol)]
 		if !ok {
@@ -107,7 +106,7 @@ func (p FinProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]Ti
 		if ok {
 			return nil, fmt.Errorf("FIN tickers response contained duplicate: %s", ticker.Symbol)
 		}
-		tickerPrices[pair.String()] = TickerPrice{
+		tickerPrices[pair.String()] = types.TickerPrice{
 			Price: strToDec(ticker.Price), 
 			Volume: strToDec(ticker.Volume),
 		}
@@ -121,18 +120,18 @@ func (p FinProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]Ti
 	return tickerPrices, nil
 }
 
-func (p FinProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]CandlePrice, error) {
+func (p FinProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]types.CandlePrice, error) {
 	pairAddresses, err := p.getFinPairAddresses()
 	if err != nil {
 		return nil, fmt.Errorf("FIN pair addresses lookup failed: %w", err)
 	}
-	candlePricesPairs := make(map[string][]CandlePrice)
+	candlePricesPairs := make(map[string][]types.CandlePrice)
 	for _, pair := range pairs {
 		address, ok := pairAddresses[pair.String()]
 		if !ok {
 			return nil, fmt.Errorf("FIN contract address lookup failed for pair: %s", pair.String())
 		}
-		candlePricesPairs[pair.String()] = []CandlePrice{}
+		candlePricesPairs[pair.String()] = []types.CandlePrice{}
 		windowEndTime := time.Now()
 		windowStartTime := windowEndTime.Add(-finCandleWindowSizeHours * time.Hour)
 		path := fmt.Sprintf("%s%s?contract=%s&precision=%d&from=%s&to=%s",
@@ -157,13 +156,13 @@ func (p FinProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]
 		if err != nil {
 			return nil, fmt.Errorf("FIN candles response unmarshal failed: %w", err)
 		}
-		candlePrices := []CandlePrice{}
+		candlePrices := []types.CandlePrice{}
 		for _, candle := range candles.Candles {
 			timeStamp, err := binToTimeStamp(candle.Bin)
 			if err != nil {
 				return nil, fmt.Errorf("FIN candle timestamp failed to parse: %s", candle.Bin)
 			}
-			candlePrices = append(candlePrices, CandlePrice{
+			candlePrices = append(candlePrices, types.CandlePrice{
 				Price:     strToDec(candle.Close),
 				Volume:    strToDec(candle.Volume),
 				TimeStamp: timeStamp,

--- a/oracle/provider/fin_test.go
+++ b/oracle/provider/fin_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"strings"
 
-	"price-feeder/config"
 	"price-feeder/oracle/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -14,7 +13,7 @@ import (
 )
 
 func TestFinProvider_GetTickerPrices(t *testing.T) {
-	p := NewFinProvider(config.ProviderEndpoint{})
+	p := NewFinProvider(Endpoint{})
 
 	t.Run("valid_request_single_ticker", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -149,7 +148,7 @@ func TestFinProvider_GetTickerPrices(t *testing.T) {
 }
 
 func TestFinProvideR_GetCandlePrices(t *testing.T) {
-	p := NewFinProvider(config.ProviderEndpoint{})
+	p := NewFinProvider(Endpoint{})
 
 	t.Run("valid_request_single_candle", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -190,7 +189,7 @@ func TestFinProvideR_GetCandlePrices(t *testing.T) {
 }
 
 func TestFinProvider_GetAvailablePairs(t *testing.T) {
-	p := NewFinProvider(config.ProviderEndpoint{})
+	p := NewFinProvider(Endpoint{})
 	p.GetAvailablePairs()
 
 	t.Run("valid_available_pair", func(t *testing.T) {

--- a/oracle/provider/gate.go
+++ b/oracle/provider/gate.go
@@ -10,17 +10,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cosmos/cosmos-sdk/telemetry"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
 
-	"price-feeder/config"
 	"price-feeder/oracle/types"
 )
 
 const (
 	gateWSHost    = "ws.gate.io"
-	gateWSPath    = "/v3"
+	gateWSPath    = "/v4"
 	gatePingCheck = time.Second * 28 // should be < 30
 	gateRestHost  = "https://api.gateio.ws"
 	gateRestPath  = "/api/v4/spot/currency_pairs"
@@ -34,12 +32,11 @@ type (
 	//
 	// REF: https://www.gate.io/docs/websocket/index.html
 	GateProvider struct {
-		wsURL           url.URL
-		wsClient        *websocket.Conn
+		wsc             *WebsocketController
 		logger          zerolog.Logger
 		reconnectTimer  *time.Ticker
 		mtx             sync.RWMutex
-		endpoints       config.ProviderEndpoint
+		endpoints       Endpoint
 		tickers         map[string]GateTicker         // Symbol => GateTicker
 		candles         map[string][]GateCandle       // Symbol => GateCandle
 		subscribedPairs map[string]types.CurrencyPair // Symbol => types.CurrencyPair
@@ -108,12 +105,12 @@ type (
 func NewGateProvider(
 	ctx context.Context,
 	logger zerolog.Logger,
-	endpoints config.ProviderEndpoint,
+	endpoints Endpoint,
 	pairs ...types.CurrencyPair,
 ) (*GateProvider, error) {
-	if endpoints.Name != config.ProviderGate {
-		endpoints = config.ProviderEndpoint{
-			Name:      config.ProviderGate,
+	if endpoints.Name != ProviderGate {
+		endpoints = Endpoint{
+			Name:      ProviderGate,
 			Rest:      gateRestHost,
 			Websocket: gateWSHost,
 		}
@@ -125,35 +122,68 @@ func NewGateProvider(
 		Path:   gateWSPath,
 	}
 
-	wsConn, _, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("error connecting to Gate websocket: %w", err)
-	}
+	gateLogger := logger.With().Str("provider", string(ProviderGate)).Logger()
 
 	provider := &GateProvider{
-		wsURL:           wsURL,
-		wsClient:        wsConn,
-		logger:          logger.With().Str("provider", "gate").Logger(),
+		logger:          gateLogger,
 		reconnectTimer:  time.NewTicker(gatePingCheck),
 		endpoints:       endpoints,
 		tickers:         map[string]GateTicker{},
 		candles:         map[string][]GateCandle{},
 		subscribedPairs: map[string]types.CurrencyPair{},
 	}
-	provider.wsClient.SetPongHandler(provider.pongHandler)
 
-	if err := provider.SubscribeCurrencyPairs(pairs...); err != nil {
-		return nil, err
-	}
+	provider.setSubscribedPairs(pairs...)
 
-	go provider.handleReceivedTickers(ctx)
+	provider.wsc = NewWebsocketController(
+		ctx,
+		ProviderGate,
+		wsURL,
+		provider.getSubscriptionMsgs(pairs...),
+		provider.messageReceived,
+		defaultPingDuration,
+		websocket.PingMessage,
+		gateLogger,
+	)
+	go provider.wsc.Start()
 
 	return provider, nil
 }
 
+func (p *GateProvider) getSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {
+	subscriptionMsgs := make([]interface{}, 0, len(cps)*2)
+	for _, cp := range cps {
+		gatePair := currencyPairToGatePair(cp)
+		subscriptionMsgs = append(subscriptionMsgs, newGateTickerSubscription(gatePair))
+		subscriptionMsgs = append(subscriptionMsgs, newGateCandleSubscription(gatePair))
+	}
+	return subscriptionMsgs
+}
+
+// SubscribeCurrencyPairs sends the new subscription messages to the websocket
+// and adds them to the providers subscribedPairs array
+func (p *GateProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	newPairs := []types.CurrencyPair{}
+	for _, cp := range cps {
+		if _, ok := p.subscribedPairs[cp.String()]; !ok {
+			newPairs = append(newPairs, cp)
+		}
+	}
+
+	newSubscriptionMsgs := p.getSubscriptionMsgs(newPairs...)
+	if err := p.wsc.AddSubscriptionMsgs(newSubscriptionMsgs); err != nil {
+		return err
+	}
+	p.setSubscribedPairs(newPairs...)
+	return nil
+}
+
 // GetTickerPrices returns the tickerPrices based on the saved map.
-func (p *GateProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]TickerPrice, error) {
-	tickerPrices := make(map[string]TickerPrice, len(pairs))
+func (p *GateProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
+	tickerPrices := make(map[string]types.TickerPrice, len(pairs))
 
 	for _, currencyPair := range pairs {
 		price, err := p.getTickerPrice(currencyPair)
@@ -168,8 +198,8 @@ func (p *GateProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]
 }
 
 // GetCandlePrices returns the candlePrices based on the saved map
-func (p *GateProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]CandlePrice, error) {
-	candlePrices := make(map[string][]CandlePrice, len(pairs))
+func (p *GateProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]types.CandlePrice, error) {
+	candlePrices := make(map[string][]types.CandlePrice, len(pairs))
 
 	for _, currencyPair := range pairs {
 		gp := currencyPairToGatePair(currencyPair)
@@ -184,20 +214,20 @@ func (p *GateProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string]
 	return candlePrices, nil
 }
 
-func (p *GateProvider) getCandlePrices(key string) ([]CandlePrice, error) {
+func (p *GateProvider) getCandlePrices(key string) ([]types.CandlePrice, error) {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
 	candles, ok := p.candles[key]
 	if !ok {
-		return []CandlePrice{}, fmt.Errorf("failed to get candle prices for %s", key)
+		return []types.CandlePrice{}, fmt.Errorf("gate failed to get candle prices for %s", key)
 	}
 
-	candleList := []CandlePrice{}
+	candleList := []types.CandlePrice{}
 	for _, candle := range candles {
 		cp, err := candle.toCandlePrice()
 		if err != nil {
-			return []CandlePrice{}, err
+			return []types.CandlePrice{}, err
 		}
 
 		candleList = append(candleList, cp)
@@ -206,77 +236,7 @@ func (p *GateProvider) getCandlePrices(key string) ([]CandlePrice, error) {
 	return candleList, nil
 }
 
-// SubscribeCurrencyPairs subscribe to ticker and candle channels for all pairs.
-func (p *GateProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
-	if len(cps) == 0 {
-		return fmt.Errorf("currency pairs is empty")
-	}
-
-	if err := p.subscribeTickers(cps...); err != nil {
-		return err
-	}
-	if err := p.subscribeCandles(cps...); err != nil {
-		return err
-	}
-	p.setSubscribedPairs(cps...)
-	telemetry.IncrCounter(
-		float32(len(cps)),
-		"websocket",
-		"subscribe",
-		"currency_pairs",
-		"provider",
-		config.ProviderGate,
-	)
-	return nil
-}
-
-// subscribeTickers subscribes to the ticker channels for all pairs at once.
-func (p *GateProvider) subscribeTickers(cps ...types.CurrencyPair) error {
-	topics := []string{}
-
-	for _, cp := range cps {
-		topics = append(topics, currencyPairToGatePair(cp))
-	}
-
-	tickerMsg := newGateTickerSubscription(topics...)
-	if err := p.subscribeTickerPairs(tickerMsg); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// subscribeCandles subscribes to the candle channels for all pairs one-by-one.
-// The gate API currently only supports subscribing to one kline market at a time.
-//
-// REF: https://www.gate.io/docs/websocket/index.html
-func (p *GateProvider) subscribeCandles(cps ...types.CurrencyPair) error {
-	gatePairs := make([]string, len(cps))
-
-	iterator := 0
-	for _, cp := range cps {
-		gatePairs[iterator] = currencyPairToGatePair(cp)
-		iterator++
-	}
-
-	for _, pair := range gatePairs {
-		msg := newGateCandleSubscription(pair)
-		if err := p.subscribeCandlePair(msg); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (p *GateProvider) subscribedPairsToSlice() []types.CurrencyPair {
-	p.mtx.RLock()
-	defer p.mtx.RUnlock()
-
-	return types.MapPairsToSlice(p.subscribedPairs)
-}
-
-func (p *GateProvider) getTickerPrice(cp types.CurrencyPair) (TickerPrice, error) {
+func (p *GateProvider) getTickerPrice(cp types.CurrencyPair) (types.TickerPrice, error) {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
@@ -285,45 +245,10 @@ func (p *GateProvider) getTickerPrice(cp types.CurrencyPair) (TickerPrice, error
 		return tickerPair.toTickerPrice()
 	}
 
-	return TickerPrice{}, fmt.Errorf("gate provider failed to get ticker price for %s", gp)
-}
-
-func (p *GateProvider) handleReceivedTickers(ctx context.Context) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(defaultReadNewWSMessage):
-			messageType, bz, err := p.wsClient.ReadMessage()
-			if err != nil {
-				// if some error occurs continue to try to read the next message.
-				p.logger.Err(err).Msg("could not read message")
-				if err := p.ping(); err != nil {
-					p.logger.Err(err).Msg("could not send ping")
-				}
-				continue
-			}
-
-			if len(bz) == 0 {
-				continue
-			}
-
-			p.resetReconnectTimer()
-			p.messageReceived(messageType, bz)
-
-		case <-p.reconnectTimer.C: // reset by the pongHandler.
-			if err := p.reconnect(); err != nil {
-				p.logger.Err(err).Msg("error reconnecting")
-			}
-		}
-	}
+	return types.TickerPrice{}, fmt.Errorf("gate failed to get ticker price for %s", gp)
 }
 
 func (p *GateProvider) messageReceived(messageType int, bz []byte) {
-	if messageType != websocket.TextMessage {
-		return
-	}
-
 	var (
 		gateEvent GateEvent
 		gateErr   error
@@ -339,14 +264,6 @@ func (p *GateProvider) messageReceived(messageType int, bz []byte) {
 		case "":
 			break
 		default:
-			err := p.reconnect()
-			if err != nil {
-				p.logger.Error().
-					AnErr("ticker", tickerErr).
-					AnErr("candle", candleErr).
-					AnErr("event", err).
-					Msg("Error on reconnecting")
-			}
 			return
 		}
 	}
@@ -402,15 +319,7 @@ func (p *GateProvider) messageReceivedTickerPrice(bz []byte) error {
 	gateTicker.Symbol = symbol
 
 	p.setTickerPair(gateTicker)
-	telemetry.IncrCounter(
-		1,
-		"websocket",
-		"message",
-		"type",
-		"ticker",
-		"provider",
-		config.ProviderGate,
-	)
+	telemetryWebsocketMessage(ProviderGate, MessageTypeTicker)
 	return nil
 }
 
@@ -476,15 +385,7 @@ func (p *GateProvider) messageReceivedCandle(bz []byte) error {
 	}
 
 	p.setCandlePair(gateCandle)
-	telemetry.IncrCounter(
-		1,
-		"websocket",
-		"message",
-		"type",
-		"candle",
-		"provider",
-		config.ProviderGate,
-	)
+	telemetryWebsocketMessage(ProviderGate, MessageTypeCandle)
 	return nil
 }
 
@@ -498,7 +399,7 @@ func (p *GateProvider) setCandlePair(candle GateCandle) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 	// convert gate timestamp seconds -> milliseconds
-	candle.TimeStamp *= int64(time.Second / time.Millisecond)
+	candle.TimeStamp = SecondsToMilli(candle.TimeStamp)
 	staleTime := PastUnixTime(providerCandlePeriod)
 	candleList := []GateCandle{}
 
@@ -511,71 +412,11 @@ func (p *GateProvider) setCandlePair(candle GateCandle) {
 	p.candles[candle.Symbol] = candleList
 }
 
-// subscribeTickerPairs write the subscription msg to the provider.
-func (p *GateProvider) subscribeTickerPairs(msg GateTickerSubscriptionMsg) error {
-	return p.wsClient.WriteJSON(msg)
-}
-
-// subscribeCandlePair write the subscription msg to the provider.
-func (p *GateProvider) subscribeCandlePair(msg GateCandleSubscriptionMsg) error {
-	return p.wsClient.WriteJSON(msg)
-}
-
 // setSubscribedPairs sets N currency pairs to the map of subscribed pairs.
 func (p *GateProvider) setSubscribedPairs(cps ...types.CurrencyPair) {
-	p.mtx.Lock()
-	defer p.mtx.Unlock()
-
 	for _, cp := range cps {
 		p.subscribedPairs[cp.String()] = cp
 	}
-}
-
-func (p *GateProvider) resetReconnectTimer() {
-	p.reconnectTimer.Reset(gatePingCheck)
-}
-
-// reconnect closes the last WS connection and creates a new one. If there’s a
-// network problem, the system will automatically disable the connection. The
-// connection will break automatically if the subscription is not established or
-// data has not been pushed for more than 30 seconds. To keep the connection stable:
-// 1. Set a timer of N seconds whenever a response message is received, where N is
-// less than 30.
-// 2. If the timer is triggered, which means that no new message is received within
-// N seconds, send the String 'ping'.
-// 3. Expect a 'pong' as a response. If the response message is not received within
-// N seconds, please raise an error or reconnect.
-func (p *GateProvider) reconnect() error {
-	p.wsClient.Close()
-
-	p.logger.Debug().Msg("reconnecting websocket")
-	wsConn, _, err := websocket.DefaultDialer.Dial(p.wsURL.String(), nil)
-	if err != nil {
-		return fmt.Errorf("error reconnecting to Gate websocket: %w", err)
-	}
-	wsConn.SetPongHandler(p.pongHandler)
-	p.wsClient = wsConn
-
-	currencyPairs := p.subscribedPairsToSlice()
-
-	telemetry.IncrCounter(
-		1,
-		"websocket",
-		"reconnect",
-		"provider",
-		config.ProviderGate,
-	)
-	return p.SubscribeCurrencyPairs(currencyPairs...)
-}
-
-// ping to check websocket connection.
-func (p *GateProvider) ping() error {
-	return p.wsClient.WriteMessage(websocket.PingMessage, ping)
-}
-
-func (p *GateProvider) pongHandler(appData string) error {
-	p.resetReconnectTimer()
-	return nil
 }
 
 // GetAvailablePairs returns all pairs to which the provider can subscribe.
@@ -603,13 +444,13 @@ func (p *GateProvider) GetAvailablePairs() (map[string]struct{}, error) {
 	return availablePairs, nil
 }
 
-func (ticker GateTicker) toTickerPrice() (TickerPrice, error) {
-	return newTickerPrice("Gate", ticker.Symbol, ticker.Last, ticker.Vol)
+func (ticker GateTicker) toTickerPrice() (types.TickerPrice, error) {
+	return types.NewTickerPrice(string(ProviderGate), ticker.Symbol, ticker.Last, ticker.Vol)
 }
 
-func (candle GateCandle) toCandlePrice() (CandlePrice, error) {
-	return newCandlePrice(
-		"Gate",
+func (candle GateCandle) toCandlePrice() (types.CandlePrice, error) {
+	return types.NewCandlePrice(
+		string(ProviderGate),
 		candle.Symbol,
 		candle.Close,
 		candle.Volume,

--- a/oracle/provider/gate_test.go
+++ b/oracle/provider/gate_test.go
@@ -2,21 +2,20 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
-
-	"price-feeder/config"
-	"price-feeder/oracle/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+	"price-feeder/oracle/types"
 )
 
 func TestGateProvider_GetTickerPrices(t *testing.T) {
 	p, err := NewGateProvider(
 		context.TODO(),
 		zerolog.Nop(),
-		config.ProviderEndpoint{},
+		Endpoint{},
 		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
 	)
 	require.NoError(t, err)
@@ -74,24 +73,8 @@ func TestGateProvider_GetTickerPrices(t *testing.T) {
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {
 		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
-		require.Error(t, err)
-		require.Equal(t, "gate provider failed to get ticker price for FOO_BAR", err.Error())
+		require.EqualError(t, err, "gate failed to get ticker price for FOO_BAR")
 		require.Nil(t, prices)
-	})
-}
-
-func TestGateProvider_SubscribeCurrencyPairs(t *testing.T) {
-	p, err := NewGateProvider(
-		context.TODO(),
-		zerolog.Nop(),
-		config.ProviderEndpoint{},
-		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
-	)
-	require.NoError(t, err)
-
-	t.Run("invalid_subscribe_channels_empty", func(t *testing.T) {
-		err = p.SubscribeCurrencyPairs([]types.CurrencyPair{}...)
-		require.ErrorContains(t, err, "currency pairs is empty")
 	})
 }
 
@@ -99,4 +82,20 @@ func TestGateCurrencyPairToGatePair(t *testing.T) {
 	cp := types.CurrencyPair{Base: "ATOM", Quote: "USDT"}
 	GateSymbol := currencyPairToGatePair(cp)
 	require.Equal(t, GateSymbol, "ATOM_USDT")
+}
+
+func TestGateProvider_getSubscriptionMsgs(t *testing.T) {
+	provider := &GateProvider{
+		subscribedPairs: map[string]types.CurrencyPair{},
+	}
+	cps := []types.CurrencyPair{
+		{Base: "ATOM", Quote: "USDT"},
+	}
+	subMsgs := provider.getSubscriptionMsgs(cps...)
+
+	msg, _ := json.Marshal(subMsgs[0])
+	require.Equal(t, "{\"method\":\"ticker.subscribe\",\"params\":[\"ATOM_USDT\"],\"id\":1}", string(msg))
+
+	msg, _ = json.Marshal(subMsgs[1])
+	require.Equal(t, "{\"method\":\"kline.subscribe\",\"params\":[\"ATOM_USDT\",60],\"id\":2}", string(msg))
 }

--- a/oracle/provider/kraken.go
+++ b/oracle/provider/kraken.go
@@ -11,12 +11,9 @@ import (
 	"sync"
 	"time"
 
-	"price-feeder/config"
-	"price-feeder/oracle/types"
-
-	"github.com/cosmos/cosmos-sdk/telemetry"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
+	"price-feeder/oracle/types"
 )
 
 const (
@@ -35,12 +32,11 @@ type (
 	//
 	// REF: https://docs.kraken.com/websockets/#overview
 	KrakenProvider struct {
-		wsURL           url.URL
-		wsClient        *websocket.Conn
+		wsc             *WebsocketController
 		logger          zerolog.Logger
 		mtx             sync.RWMutex
-		endpoints       config.ProviderEndpoint
-		tickers         map[string]TickerPrice        // Symbol => TickerPrice
+		endpoints       Endpoint
+		tickers         map[string]types.TickerPrice  // Symbol => TickerPrice
 		candles         map[string][]KrakenCandle     // Symbol => KrakenCandle
 		subscribedPairs map[string]types.CurrencyPair // Symbol => types.CurrencyPair
 	}
@@ -78,11 +74,6 @@ type (
 		Event string `json:"event"` // events from kraken ex.: systemStatus | subscriptionStatus
 	}
 
-	// KrakenEventSystemStatus parse the systemStatus event message.
-	KrakenEventSystemStatus struct {
-		Status string `json:"status"` // online|maintenance|cancel_only|limit_only|post_only
-	}
-
 	// KrakenEventSubscriptionStatus parse the subscriptionStatus event message.
 	KrakenEventSubscriptionStatus struct {
 		Status       string `json:"status"`       // subscribed|unsubscribed|error
@@ -105,12 +96,12 @@ type (
 func NewKrakenProvider(
 	ctx context.Context,
 	logger zerolog.Logger,
-	endpoints config.ProviderEndpoint,
+	endpoints Endpoint,
 	pairs ...types.CurrencyPair,
 ) (*KrakenProvider, error) {
-	if endpoints.Name != config.ProviderKraken {
-		endpoints = config.ProviderEndpoint{
-			Name:      config.ProviderKraken,
+	if endpoints.Name != ProviderKraken {
+		endpoints = Endpoint{
+			Name:      ProviderKraken,
 			Rest:      KrakenRestHost,
 			Websocket: krakenWSHost,
 		}
@@ -121,42 +112,76 @@ func NewKrakenProvider(
 		Host:   endpoints.Websocket,
 	}
 
-	wsConn, _, err := websocket.DefaultDialer.Dial(wsURL.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("error connecting to websocket: %w", err)
-	}
+	krakenLogger := logger.With().Str("provider", string(ProviderKraken)).Logger()
 
 	provider := &KrakenProvider{
-		wsURL:           wsURL,
-		wsClient:        wsConn,
-		logger:          logger.With().Str("provider", "kraken").Logger(),
+		logger:          krakenLogger,
 		endpoints:       endpoints,
-		tickers:         map[string]TickerPrice{},
+		tickers:         map[string]types.TickerPrice{},
 		candles:         map[string][]KrakenCandle{},
 		subscribedPairs: map[string]types.CurrencyPair{},
 	}
 
-	if err := provider.SubscribeCurrencyPairs(pairs...); err != nil {
-		return nil, err
-	}
+	provider.setSubscribedPairs(pairs...)
 
-	go provider.handleWebSocketMsgs(ctx)
+	provider.wsc = NewWebsocketController(
+		ctx,
+		ProviderKraken,
+		wsURL,
+		provider.getSubscriptionMsgs(pairs...),
+		provider.messageReceived,
+		time.Duration(0),
+		websocket.PingMessage,
+		krakenLogger,
+	)
+	go provider.wsc.Start()
 
 	return provider, nil
 }
 
+func (p *KrakenProvider) getSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {
+	subscriptionMsgs := make([]interface{}, 0, len(cps)*2)
+	for _, cp := range cps {
+		krakenPair := currencyPairToKrakenPair(cp)
+		subscriptionMsgs = append(subscriptionMsgs, newKrakenTickerSubscriptionMsg(krakenPair))
+		subscriptionMsgs = append(subscriptionMsgs, newKrakenCandleSubscriptionMsg(krakenPair))
+	}
+	return subscriptionMsgs
+}
+
+// SubscribeCurrencyPairs sends the new subscription messages to the websocket
+// and adds them to the providers subscribedPairs array
+func (p *KrakenProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	newPairs := []types.CurrencyPair{}
+	for _, cp := range cps {
+		if _, ok := p.subscribedPairs[cp.String()]; !ok {
+			newPairs = append(newPairs, cp)
+		}
+	}
+
+	newSubscriptionMsgs := p.getSubscriptionMsgs(newPairs...)
+	if err := p.wsc.AddSubscriptionMsgs(newSubscriptionMsgs); err != nil {
+		return err
+	}
+	p.setSubscribedPairs(newPairs...)
+	return nil
+}
+
 // GetTickerPrices returns the tickerPrices based on the saved map.
-func (p *KrakenProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]TickerPrice, error) {
+func (p *KrakenProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
-	tickerPrices := make(map[string]TickerPrice, len(pairs))
+	tickerPrices := make(map[string]types.TickerPrice, len(pairs))
 
 	for _, cp := range pairs {
 		key := cp.String()
 		tickerPrice, ok := p.tickers[key]
 		if !ok {
-			return nil, fmt.Errorf("failed to get ticker price for %s", key)
+			return nil, fmt.Errorf("kraken failed to get ticker price for %s", key)
 		}
 		tickerPrices[key] = tickerPrice
 	}
@@ -165,8 +190,8 @@ func (p *KrakenProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[strin
 }
 
 // GetCandlePrices returns the candlePrices based on the saved map.
-func (p *KrakenProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]CandlePrice, error) {
-	candlePrices := make(map[string][]CandlePrice, len(pairs))
+func (p *KrakenProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]types.CandlePrice, error) {
+	candlePrices := make(map[string][]types.CandlePrice, len(pairs))
 
 	for _, cp := range pairs {
 		key := cp.String()
@@ -180,54 +205,9 @@ func (p *KrakenProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[strin
 	return candlePrices, nil
 }
 
-// SubscribeCurrencyPairs subscribe all currency pairs into ticker and candle channels.
-func (p *KrakenProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
-	if len(cps) == 0 {
-		return fmt.Errorf("currency pairs is empty")
-	}
-
-	if err := p.subscribeChannels(cps...); err != nil {
-		return err
-	}
-
-	p.setSubscribedPairs(cps...)
-	telemetry.IncrCounter(
-		float32(len(cps)),
-		"websocket",
-		"subscribe",
-		"currency_pairs",
-		"provider",
-		config.ProviderKraken,
-	)
-	return nil
-}
-
-// subscribeChannels subscribe all currency pairs into ticker and candle channels.
-func (p *KrakenProvider) subscribeChannels(cps ...types.CurrencyPair) error {
-	pairs := make([]string, len(cps))
-
-	for i, cp := range cps {
-		pairs[i] = currencyPairToKrakenPair(cp)
-	}
-
-	if err := p.subscribeTickers(pairs...); err != nil {
-		return err
-	}
-
-	return p.subscribeCandles(pairs...)
-}
-
-// subscribedPairsToSlice returns the map of subscribed pairs as slice
-func (p *KrakenProvider) subscribedPairsToSlice() []types.CurrencyPair {
-	p.mtx.RLock()
-	defer p.mtx.RUnlock()
-
-	return types.MapPairsToSlice(p.subscribedPairs)
-}
-
-func (candle KrakenCandle) toCandlePrice() (CandlePrice, error) {
-	return newCandlePrice(
-		"Kraken",
+func (candle KrakenCandle) toCandlePrice() (types.CandlePrice, error) {
+	return types.NewCandlePrice(
+		string(ProviderKraken),
 		candle.Symbol,
 		candle.Close,
 		candle.Volume,
@@ -235,67 +215,24 @@ func (candle KrakenCandle) toCandlePrice() (CandlePrice, error) {
 	)
 }
 
-func (p *KrakenProvider) getCandlePrices(key string) ([]CandlePrice, error) {
+func (p *KrakenProvider) getCandlePrices(key string) ([]types.CandlePrice, error) {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
 	candles, ok := p.candles[key]
 	if !ok {
-		return []CandlePrice{}, fmt.Errorf("failed to get candle prices for %s", key)
+		return []types.CandlePrice{}, fmt.Errorf("kraken failed to get candle prices for %s", key)
 	}
 
-	candleList := []CandlePrice{}
+	candleList := []types.CandlePrice{}
 	for _, candle := range candles {
 		cp, err := candle.toCandlePrice()
 		if err != nil {
-			return []CandlePrice{}, err
+			return []types.CandlePrice{}, err
 		}
 		candleList = append(candleList, cp)
 	}
 	return candleList, nil
-}
-
-// handleWebSocketMsgs receive all the messages from the provider and controls the
-// reconnect function to the web socket.
-func (p *KrakenProvider) handleWebSocketMsgs(ctx context.Context) {
-	reconnectTicker := time.NewTicker(defaultMaxConnectionTime)
-	defer reconnectTicker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(defaultReadNewWSMessage):
-			messageType, bz, err := p.wsClient.ReadMessage()
-			if err != nil {
-				if websocket.IsCloseError(err, websocket.CloseAbnormalClosure) {
-					p.logger.Err(err).Msg("WebSocket closed unexpectedly")
-					p.keepReconnecting()
-					continue
-				}
-
-				// if some error occurs continue to try to read the next message.
-				p.logger.Err(err).Msg("could not read message")
-				if err := p.ping(); err != nil {
-					p.logger.Err(err).Msg("failed to send ping")
-					p.keepReconnecting()
-				}
-				continue
-			}
-
-			if len(bz) == 0 {
-				continue
-			}
-
-			p.messageReceived(messageType, bz)
-
-		case <-reconnectTicker.C:
-			if err := p.reconnect(); err != nil {
-				p.logger.Err(err).Msg("attempted to reconnect")
-				p.keepReconnecting()
-			}
-		}
-	}
 }
 
 // messageReceived handles any message sent by the provider.
@@ -315,7 +252,6 @@ func (p *KrakenProvider) messageReceived(messageType int, bz []byte) {
 	if krakenErr == nil {
 		switch krakenEvent.Event {
 		case krakenEventSystemStatus:
-			p.messageReceivedSystemStatus(bz)
 			return
 		case krakenEventSubscriptionStatus:
 			p.messageReceivedSubscriptionStatus(bz)
@@ -388,15 +324,7 @@ func (p *KrakenProvider) messageReceivedTickerPrice(bz []byte) error {
 	}
 
 	p.setTickerPair(currencyPairSymbol, tickerPrice)
-	telemetry.IncrCounter(
-		1,
-		"websocket",
-		"message",
-		"type",
-		"ticker",
-		"provider",
-		config.ProviderKraken,
-	)
+	telemetryWebsocketMessage(ProviderKraken, MessageTypeTicker)
 	return nil
 }
 
@@ -472,60 +400,9 @@ func (p *KrakenProvider) messageReceivedCandle(bz []byte) error {
 	currencyPairSymbol := krakenPairToCurrencyPairSymbol(krakenPair)
 	krakenCandle.Symbol = currencyPairSymbol
 
-	telemetry.IncrCounter(
-		1,
-		"websocket",
-		"message",
-		"type",
-		"candle",
-		"provider",
-		config.ProviderKraken,
-	)
+	telemetryWebsocketMessage(ProviderKraken, MessageTypeCandle)
 	p.setCandlePair(krakenCandle)
 	return nil
-}
-
-// reconnect closes the last WS connection and create a new one.
-func (p *KrakenProvider) reconnect() error {
-	p.wsClient.Close()
-	p.logger.Debug().Msg("trying to reconnect")
-
-	wsConn, _, err := websocket.DefaultDialer.Dial(p.wsURL.String(), nil)
-	if err != nil {
-		return fmt.Errorf("error connecting to Kraken websocket: %w", err)
-	}
-	p.wsClient = wsConn
-
-	currencyPairs := p.subscribedPairsToSlice()
-
-	telemetry.IncrCounter(
-		1,
-		"websocket",
-		"reconnect",
-		"provider",
-		config.ProviderKraken,
-	)
-	return p.subscribeChannels(currencyPairs...)
-}
-
-// keepReconnecting keeps trying to reconnect if an error occurs in recconnect.
-func (p *KrakenProvider) keepReconnecting() {
-	reconnectTicker := time.NewTicker(defaultReconnectTime)
-	defer reconnectTicker.Stop()
-	connectionTries := 1
-
-	for time := range reconnectTicker.C {
-		if err := p.reconnect(); err != nil {
-			p.logger.Err(err).Msgf("attempted to reconnect %d times at %s", connectionTries, time.String())
-			connectionTries++
-			continue
-		}
-
-		if connectionTries > maxReconnectionTries {
-			p.logger.Warn().Msgf("failed to reconnect %d times", connectionTries)
-		}
-		return
-	}
 }
 
 // messageReceivedSubscriptionStatus handle the subscription status message
@@ -549,24 +426,8 @@ func (p *KrakenProvider) messageReceivedSubscriptionStatus(bz []byte) {
 	}
 }
 
-// messageReceivedSystemStatus handle the system status and try to reconnect if it
-// is not online.
-func (p *KrakenProvider) messageReceivedSystemStatus(bz []byte) {
-	var systemStatus KrakenEventSystemStatus
-	if err := json.Unmarshal(bz, &systemStatus); err != nil {
-		p.logger.Err(err).Msg("could not unmarshal event system status")
-		return
-	}
-
-	if strings.EqualFold(systemStatus.Status, "online") {
-		return
-	}
-
-	p.keepReconnecting()
-}
-
 // setTickerPair sets an ticker to the map thread safe by the mutex.
-func (p *KrakenProvider) setTickerPair(symbol string, ticker TickerPrice) {
+func (p *KrakenProvider) setTickerPair(symbol string, ticker types.TickerPrice) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 	p.tickers[symbol] = ticker
@@ -576,7 +437,7 @@ func (p *KrakenProvider) setCandlePair(candle KrakenCandle) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 	// convert kraken timestamp seconds -> milliseconds
-	candle.TimeStamp *= int64(time.Second / time.Millisecond)
+	candle.TimeStamp = SecondsToMilli(candle.TimeStamp)
 	staleTime := PastUnixTime(providerCandlePeriod)
 	candleList := []KrakenCandle{}
 
@@ -589,28 +450,8 @@ func (p *KrakenProvider) setCandlePair(candle KrakenCandle) {
 	p.candles[candle.Symbol] = candleList
 }
 
-// ping to check websocket connection.
-func (p *KrakenProvider) ping() error {
-	return p.wsClient.WriteMessage(websocket.PingMessage, ping)
-}
-
-// subscribeTickers write the subscription msg to the provider.
-func (p *KrakenProvider) subscribeTickers(pairs ...string) error {
-	subsMsg := newKrakenTickerSubscriptionMsg(pairs...)
-	return p.wsClient.WriteJSON(subsMsg)
-}
-
-// subscribeCandles write the subscription msg to the provider.
-func (p *KrakenProvider) subscribeCandles(pairs ...string) error {
-	subsMsg := newKrakenCandleSubscriptionMsg(pairs...)
-	return p.wsClient.WriteJSON(subsMsg)
-}
-
 // setSubscribedPairs sets N currency pairs to the map of subscribed pairs.
 func (p *KrakenProvider) setSubscribedPairs(cps ...types.CurrencyPair) {
-	p.mtx.Lock()
-	defer p.mtx.Unlock()
-
 	for _, cp := range cps {
 		p.subscribedPairs[cp.String()] = cp
 	}
@@ -657,13 +498,13 @@ func (p *KrakenProvider) GetAvailablePairs() (map[string]struct{}, error) {
 }
 
 // toTickerPrice return a TickerPrice based on the KrakenTicker.
-func (ticker KrakenTicker) toTickerPrice(symbol string) (TickerPrice, error) {
+func (ticker KrakenTicker) toTickerPrice(symbol string) (types.TickerPrice, error) {
 	if len(ticker.C) != 2 || len(ticker.V) != 2 {
-		return TickerPrice{}, fmt.Errorf("error converting KrakenTicker to TickerPrice")
+		return types.TickerPrice{}, fmt.Errorf("error converting KrakenTicker to TickerPrice")
 	}
 	// ticker.C has the Price in the first position.
 	// ticker.V has the totla	Value over last 24 hours in the second position.
-	return newTickerPrice("Kraken", symbol, ticker.C[0], ticker.V[1])
+	return types.NewTickerPrice(string(ProviderKraken), symbol, ticker.C[0], ticker.V[1])
 }
 
 // newKrakenTickerSubscriptionMsg returns a new subscription Msg.

--- a/oracle/provider/mock_test.go
+++ b/oracle/provider/mock_test.go
@@ -5,10 +5,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"price-feeder/oracle/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
+	"price-feeder/oracle/types"
 )
 
 func TestMockProvider_GetTickerPrices(t *testing.T) {

--- a/oracle/provider/osmosis.go
+++ b/oracle/provider/osmosis.go
@@ -3,15 +3,11 @@ package provider
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
-	"strconv"
 	"strings"
 
-	"price-feeder/config"
 	"price-feeder/oracle/types"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 const (
@@ -62,8 +58,8 @@ type (
 	}
 )
 
-func NewOsmosisProvider(endpoint config.ProviderEndpoint) *OsmosisProvider {
-	if endpoint.Name == config.ProviderOsmosis {
+func NewOsmosisProvider(endpoint Endpoint) *OsmosisProvider {
+	if endpoint.Name == ProviderOsmosis {
 		return &OsmosisProvider{
 			baseURL: endpoint.Rest,
 			client:  newDefaultHTTPClient(),
@@ -75,17 +71,26 @@ func NewOsmosisProvider(endpoint config.ProviderEndpoint) *OsmosisProvider {
 	}
 }
 
-func (p OsmosisProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]TickerPrice, error) {
+// SubscribeCurrencyPairs performs a no-op since osmosis does not use websockets
+func (p OsmosisProvider) SubscribeCurrencyPairs(pairs ...types.CurrencyPair) error {
+	return nil
+}
+
+func (p OsmosisProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
 	path := fmt.Sprintf("%s%s/all", p.baseURL, osmosisTokenEndpoint)
 
 	resp, err := p.client.Get(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make Osmosis request: %w", err)
 	}
+	err = checkHTTPStatus(resp)
+	if err != nil {
+		return nil, err
+	}
 
 	defer resp.Body.Close()
 
-	bz, err := ioutil.ReadAll(resp.Body)
+	bz, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read Osmosis response body: %w", err)
 	}
@@ -100,7 +105,7 @@ func (p OsmosisProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[strin
 		baseDenomIdx[strings.ToUpper(cp.Base)] = cp
 	}
 
-	tickerPrices := make(map[string]TickerPrice, len(pairs))
+	tickerPrices := make(map[string]types.TickerPrice, len(pairs))
 	for _, tr := range tokensResp {
 		symbol := strings.ToUpper(tr.Symbol) // symbol == base in a currency pair
 
@@ -114,35 +119,26 @@ func (p OsmosisProvider) GetTickerPrices(pairs ...types.CurrencyPair) (map[strin
 			return nil, fmt.Errorf("duplicate token found in Osmosis response: %s", symbol)
 		}
 
-		priceRaw := strconv.FormatFloat(tr.Price, 'f', -1, 64)
-		price, err := sdk.NewDecFromStr(priceRaw)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read Osmosis price (%s) for %s", priceRaw, symbol)
+		tickerPrices[cp.String()] = types.TickerPrice{
+			Price: floatToDec(tr.Price),
+			Volume: floatToDec(tr.Volume),
 		}
-
-		volumeRaw := strconv.FormatFloat(tr.Volume, 'f', -1, 64)
-		volume, err := sdk.NewDecFromStr(volumeRaw)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read Osmosis volume (%s) for %s", volumeRaw, symbol)
-		}
-
-		tickerPrices[cp.String()] = TickerPrice{Price: price, Volume: volume}
 	}
 
 	for _, cp := range pairs {
 		if _, ok := tickerPrices[cp.String()]; !ok {
-			return nil, fmt.Errorf("missing exchange rate for %s", cp.String())
+			return nil, fmt.Errorf(types.ErrMissingExchangeRate.Error(), cp.String())
 		}
 	}
 
 	return tickerPrices, nil
 }
 
-func (p OsmosisProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]CandlePrice, error) {
-	candles := make(map[string][]CandlePrice)
+func (p OsmosisProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]types.CandlePrice, error) {
+	candles := make(map[string][]types.CandlePrice)
 	for _, pair := range pairs {
 		if _, ok := candles[pair.Base]; !ok {
-			candles[pair.String()] = []CandlePrice{}
+			candles[pair.String()] = []types.CandlePrice{}
 		}
 
 		path := fmt.Sprintf("%s%s/%s/chart?tf=5", p.baseURL, osmosisCandleEndpoint, pair.Base)
@@ -151,10 +147,14 @@ func (p OsmosisProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[strin
 		if err != nil {
 			return nil, fmt.Errorf("failed to make Osmosis request: %w", err)
 		}
+		err = checkHTTPStatus(resp)
+		if err != nil {
+			return nil, err
+		}
 
 		defer resp.Body.Close()
 
-		bz, err := ioutil.ReadAll(resp.Body)
+		bz, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read Osmosis response body: %w", err)
 		}
@@ -164,14 +164,18 @@ func (p OsmosisProvider) GetCandlePrices(pairs ...types.CurrencyPair) (map[strin
 			return nil, fmt.Errorf("failed to unmarshal Osmosis response body: %w", err)
 		}
 
-		candlePrices := []CandlePrice{}
+		staleTime := PastUnixTime(providerCandlePeriod)
+
+		candlePrices := []types.CandlePrice{}
 		for _, responseCandle := range candlesResp {
-			closeStr := fmt.Sprintf("%f", responseCandle.Close)
-			volumeStr := fmt.Sprintf("%f", responseCandle.Volume)
-			candlePrices = append(candlePrices, CandlePrice{
-				Price:     sdk.MustNewDecFromStr(closeStr),
-				Volume:    sdk.MustNewDecFromStr(volumeStr),
-				TimeStamp: responseCandle.Time,
+			if staleTime >= responseCandle.Time {
+				continue
+			}
+			candlePrices = append(candlePrices, types.CandlePrice{
+				Price:  floatToDec(responseCandle.Close),
+				Volume: floatToDec(responseCandle.Volume),
+				// convert osmosis timestamp seconds -> milliseconds
+				TimeStamp: SecondsToMilli(responseCandle.Time),
 			})
 		}
 		candles[pair.String()] = candlePrices
@@ -185,6 +189,10 @@ func (p OsmosisProvider) GetAvailablePairs() (map[string]struct{}, error) {
 	path := fmt.Sprintf("%s%s", p.baseURL, osmosisPairsEndpoint)
 
 	resp, err := p.client.Get(path)
+	if err != nil {
+		return nil, err
+	}
+	err = checkHTTPStatus(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -205,9 +213,4 @@ func (p OsmosisProvider) GetAvailablePairs() (map[string]struct{}, error) {
 	}
 
 	return availablePairs, nil
-}
-
-// SubscribeCurrencyPairs performs a no-op since osmosis does not use websockets
-func (p OsmosisProvider) SubscribeCurrencyPairs(pairs ...types.CurrencyPair) error {
-	return nil
 }

--- a/oracle/provider/osmosis_test.go
+++ b/oracle/provider/osmosis_test.go
@@ -5,15 +5,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"price-feeder/config"
-	"price-feeder/oracle/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
+	"price-feeder/oracle/types"
 )
 
 func TestOsmosisProvider_GetTickerPrices(t *testing.T) {
-	p := NewOsmosisProvider(config.ProviderEndpoint{})
+	p := NewOsmosisProvider(Endpoint{})
 
 	t.Run("valid_request_single_ticker", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -158,7 +156,7 @@ func TestOsmosisProvider_GetTickerPrices(t *testing.T) {
 }
 
 func TestOsmosisProvider_GetAvailablePairs(t *testing.T) {
-	p := NewOsmosisProvider(config.ProviderEndpoint{})
+	p := NewOsmosisProvider(Endpoint{})
 	p.GetAvailablePairs()
 
 	t.Run("valid_available_pair", func(t *testing.T) {

--- a/oracle/provider/osmosisv2.go
+++ b/oracle/provider/osmosisv2.go
@@ -1,0 +1,357 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/gorilla/websocket"
+	"github.com/rs/zerolog"
+	"price-feeder/oracle/types"
+)
+
+const (
+	osmosisV2WSHost   = "api.osmo-api.network.umee.cc"
+	osmosisV2WSPath   = "ws"
+	osmosisV2RestHost = "https://api.osmo-api.network.umee.cc"
+	osmosisV2RestPath = "/assetpairs"
+)
+
+var _ Provider = (*OsmosisV2Provider)(nil)
+
+type (
+	// OsmosisV2Provider defines an Oracle provider implemented by UMEE's
+	// Osmosis API.
+	//
+	// REF: https://github.com/umee-network/osmosis-api
+	OsmosisV2Provider struct {
+		wsc             *WebsocketController
+		wsURL           url.URL
+		logger          zerolog.Logger
+		mtx             sync.RWMutex
+		endpoints       Endpoint
+		tickers         map[string]types.TickerPrice   // Symbol => TickerPrice
+		candles         map[string][]types.CandlePrice // Symbol => CandlePrice
+		subscribedPairs map[string]types.CurrencyPair  // Symbol => types.CurrencyPair
+	}
+
+	OsmosisV2Ticker struct {
+		Price  string `json:"Price"`
+		Volume string `json:"Volume"`
+	}
+
+	OsmosisV2Candle struct {
+		Close   string `json:"Close"`
+		Volume  string `json:"Volume"`
+		EndTime int64  `json:"EndTime"`
+	}
+
+	// OsmosisV2PairsSummary defines the response structure for an Osmosis pairs
+	// summary.
+	OsmosisV2PairsSummary struct {
+		Data []OsmosisPairData `json:"data"`
+	}
+
+	// OsmosisV2PairData defines the data response structure for an Osmosis pair.
+	OsmosisV2PairData struct {
+		Base  string `json:"base_symbol"`
+		Quote string `json:"quote_symbol"`
+	}
+)
+
+func NewOsmosisV2Provider(
+	ctx context.Context,
+	logger zerolog.Logger,
+	endpoints Endpoint,
+	pairs ...types.CurrencyPair,
+) (*OsmosisV2Provider, error) {
+	if endpoints.Name != ProviderOsmosisV2 {
+		endpoints = Endpoint{
+			Name:      ProviderOsmosisV2,
+			Rest:      osmosisV2RestHost,
+			Websocket: osmosisV2WSHost,
+		}
+	}
+
+	wsURL := url.URL{
+		Scheme: "wss",
+		Host:   endpoints.Websocket,
+		Path:   osmosisV2WSPath,
+	}
+
+	osmosisV2Logger := logger.With().Str("provider", "osmosisv2").Logger()
+
+	provider := &OsmosisV2Provider{
+		wsURL:           wsURL,
+		logger:          osmosisV2Logger,
+		endpoints:       endpoints,
+		tickers:         map[string]types.TickerPrice{},
+		candles:         map[string][]types.CandlePrice{},
+		subscribedPairs: map[string]types.CurrencyPair{},
+	}
+
+	provider.setSubscribedPairs(pairs...)
+
+	provider.wsc = NewWebsocketController(
+		ctx,
+		ProviderOsmosisV2,
+		wsURL,
+		[]interface{}{""},
+		provider.messageReceived,
+		defaultPingDuration,
+		websocket.PingMessage,
+		osmosisV2Logger,
+	)
+	go provider.wsc.Start()
+
+	return provider, nil
+}
+
+// SubscribeCurrencyPairs sends the new subscription messages to the websocket
+// and adds them to the providers subscribedPairs array
+func (p *OsmosisV2Provider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	p.setSubscribedPairs(cps...)
+	return nil
+}
+
+// GetTickerPrices returns the tickerPrices based on the saved map.
+func (p *OsmosisV2Provider) GetTickerPrices(pairs ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
+	tickerPrices := make(map[string]types.TickerPrice, len(pairs))
+
+	for _, cp := range pairs {
+		key := currencyPairToOsmosisV2Pair(cp)
+		price, err := p.getTickerPrice(key)
+		if err != nil {
+			return nil, err
+		}
+		tickerPrices[cp.String()] = price
+	}
+
+	return tickerPrices, nil
+}
+
+// GetCandlePrices returns the candlePrices based on the saved map
+func (p *OsmosisV2Provider) GetCandlePrices(pairs ...types.CurrencyPair) (map[string][]types.CandlePrice, error) {
+	candlePrices := make(map[string][]types.CandlePrice, len(pairs))
+
+	for _, cp := range pairs {
+		key := currencyPairToOsmosisV2Pair(cp)
+		prices, err := p.getCandlePrices(key)
+		if err != nil {
+			return nil, err
+		}
+		candlePrices[cp.String()] = prices
+	}
+
+	return candlePrices, nil
+}
+
+func (p *OsmosisV2Provider) getTickerPrice(key string) (types.TickerPrice, error) {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	ticker, ok := p.tickers[key]
+	if !ok {
+		return types.TickerPrice{}, fmt.Errorf(
+			types.ErrTickerNotFound.Error(),
+			ProviderOsmosisV2,
+			key,
+		)
+	}
+
+	return ticker, nil
+}
+
+func (p *OsmosisV2Provider) getCandlePrices(key string) ([]types.CandlePrice, error) {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	candles, ok := p.candles[key]
+	if !ok {
+		return []types.CandlePrice{}, fmt.Errorf(
+			types.ErrCandleNotFound.Error(),
+			ProviderOsmosisV2,
+			key,
+		)
+	}
+
+	candleList := []types.CandlePrice{}
+	candleList = append(candleList, candles...)
+
+	return candleList, nil
+}
+
+func (p *OsmosisV2Provider) messageReceived(messageType int, bz []byte) {
+	// check if message is an ack first
+	if string(bz) == "ack" {
+		return
+	}
+
+	var (
+		messageResp map[string]interface{}
+		messageErr  error
+		tickerResp  OsmosisV2Ticker
+		tickerErr   error
+		candleResp  []OsmosisV2Candle
+		candleErr   error
+	)
+
+	messageErr = json.Unmarshal(bz, &messageResp)
+	if messageErr != nil {
+		p.logger.Error().
+			Int("length", len(bz)).
+			AnErr("message", messageErr).
+			Msg("Error on receive message")
+	}
+
+	// Check the response for currency pairs that the provider is subscribed
+	// to and determine whether it is a ticker or candle.
+	for _, pair := range p.subscribedPairs {
+		osmosisV2Pair := currencyPairToOsmosisV2Pair(pair)
+		if msg, ok := messageResp[osmosisV2Pair]; ok {
+			switch v := msg.(type) {
+			// ticker response
+			case map[string]interface{}:
+				tickerString, _ := json.Marshal(v)
+				tickerErr = json.Unmarshal(tickerString, &tickerResp)
+				if tickerErr != nil {
+					p.logger.Error().
+						Int("length", len(bz)).
+						AnErr("ticker", tickerErr).
+						Msg("Error on receive message")
+					continue
+				}
+				p.setTickerPair(
+					osmosisV2Pair,
+					tickerResp,
+				)
+				telemetryWebsocketMessage(ProviderOsmosisV2, MessageTypeTicker)
+				continue
+
+			// candle response
+			case []interface{}:
+				// use latest candlestick in list if there is one
+				if len(v) == 0 {
+					continue
+				}
+				candleString, _ := json.Marshal(v)
+				candleErr = json.Unmarshal(candleString, &candleResp)
+				if candleErr != nil {
+					p.logger.Error().
+						Int("length", len(bz)).
+						AnErr("candle", candleErr).
+						Msg("Error on receive message")
+					continue
+				}
+				for _, singleCandle := range candleResp {
+					p.setCandlePair(
+						osmosisV2Pair,
+						singleCandle,
+					)
+				}
+				telemetryWebsocketMessage(ProviderOsmosisV2, MessageTypeCandle)
+				continue
+			}
+		}
+	}
+}
+
+func (p *OsmosisV2Provider) setTickerPair(symbol string, tickerPair OsmosisV2Ticker) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	price, err := sdk.NewDecFromStr(tickerPair.Price)
+	if err != nil {
+		p.logger.Warn().Err(err).Msg("osmosisv2: failed to parse ticker price")
+		return
+	}
+	volume, err := sdk.NewDecFromStr(tickerPair.Volume)
+	if err != nil {
+		p.logger.Warn().Err(err).Msg("osmosisv2: failed to parse ticker volume")
+		return
+	}
+
+	p.tickers[symbol] = types.TickerPrice{
+		Price:  price,
+		Volume: volume,
+	}
+}
+
+func (p *OsmosisV2Provider) setCandlePair(symbol string, candlePair OsmosisV2Candle) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	close, err := sdk.NewDecFromStr(candlePair.Close)
+	if err != nil {
+		p.logger.Warn().Err(err).Msg("osmosisv2: failed to parse candle close")
+		return
+	}
+	volume, err := sdk.NewDecFromStr(candlePair.Volume)
+	if err != nil {
+		p.logger.Warn().Err(err).Msg("osmosisv2: failed to parse candle volume")
+		return
+	}
+	candle := types.CandlePrice{
+		Price:     close,
+		Volume:    volume,
+		TimeStamp: candlePair.EndTime,
+	}
+
+	staleTime := PastUnixTime(providerCandlePeriod)
+	candleList := []types.CandlePrice{}
+	candleList = append(candleList, candle)
+	for _, c := range p.candles[symbol] {
+		if staleTime < c.TimeStamp {
+			candleList = append(candleList, c)
+		}
+	}
+
+	p.candles[symbol] = candleList
+}
+
+// setSubscribedPairs sets N currency pairs to the map of subscribed pairs.
+func (p *OsmosisV2Provider) setSubscribedPairs(cps ...types.CurrencyPair) {
+	for _, cp := range cps {
+		p.subscribedPairs[cp.String()] = cp
+	}
+}
+
+// GetAvailablePairs returns all pairs to which the provider can subscribe.
+// ex.: map["ATOMUSDT" => {}, "UMEEUSDC" => {}].
+func (p *OsmosisV2Provider) GetAvailablePairs() (map[string]struct{}, error) {
+	resp, err := http.Get(p.endpoints.Rest + osmosisV2RestPath)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var pairsSummary OsmosisV2PairsSummary
+	if err := json.NewDecoder(resp.Body).Decode(&pairsSummary); err != nil {
+		return nil, err
+	}
+
+	availablePairs := make(map[string]struct{}, len(pairsSummary.Data))
+	for _, pair := range pairsSummary.Data {
+		cp := types.CurrencyPair{
+			Base:  strings.ToUpper(pair.Base),
+			Quote: strings.ToUpper(pair.Quote),
+		}
+		availablePairs[cp.String()] = struct{}{}
+	}
+
+	return availablePairs, nil
+}
+
+// currencyPairToOsmosisV2Pair receives a currency pair and return osmosisv2
+// ticker symbol atomusdt@ticker.
+func currencyPairToOsmosisV2Pair(cp types.CurrencyPair) string {
+	return strings.ToUpper(cp.Base + "/" + cp.Quote)
+}

--- a/oracle/provider/osmosisv2_test.go
+++ b/oracle/provider/osmosisv2_test.go
@@ -1,0 +1,119 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	"price-feeder/oracle/types"
+)
+
+func TestOsmosisV2Provider_GetTickerPrices(t *testing.T) {
+	p, err := NewOsmosisV2Provider(
+		context.TODO(),
+		zerolog.Nop(),
+		Endpoint{},
+		types.CurrencyPair{Base: "OSMO", Quote: "ATOM"},
+	)
+	require.NoError(t, err)
+
+	t.Run("valid_request_single_ticker", func(t *testing.T) {
+		lastPrice := sdk.MustNewDecFromStr("34.69000000")
+		volume := sdk.MustNewDecFromStr("2396974.02000000")
+
+		tickerMap := map[string]types.TickerPrice{}
+		tickerMap["OSMO/ATOM"] = types.TickerPrice{
+			Price:  lastPrice,
+			Volume: volume,
+		}
+
+		p.tickers = tickerMap
+
+		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "OSMO", Quote: "ATOM"})
+		require.NoError(t, err)
+		require.Len(t, prices, 1)
+		require.Equal(t, lastPrice, prices["OSMOATOM"].Price)
+		require.Equal(t, volume, prices["OSMOATOM"].Volume)
+	})
+
+	t.Run("valid_request_multi_ticker", func(t *testing.T) {
+		lastPriceAtom := sdk.MustNewDecFromStr("34.69000000")
+		lastPriceLuna := sdk.MustNewDecFromStr("41.35000000")
+		volume := sdk.MustNewDecFromStr("2396974.02000000")
+
+		tickerMap := map[string]types.TickerPrice{}
+		tickerMap["ATOM/USDT"] = types.TickerPrice{
+			Price:  lastPriceAtom,
+			Volume: volume,
+		}
+
+		tickerMap["LUNA/USDT"] = types.TickerPrice{
+			Price:  lastPriceLuna,
+			Volume: volume,
+		}
+
+		p.tickers = tickerMap
+		prices, err := p.GetTickerPrices(
+			types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
+			types.CurrencyPair{Base: "LUNA", Quote: "USDT"},
+		)
+		require.NoError(t, err)
+		require.Len(t, prices, 2)
+		require.Equal(t, lastPriceAtom, prices["ATOMUSDT"].Price)
+		require.Equal(t, volume, prices["ATOMUSDT"].Volume)
+		require.Equal(t, lastPriceLuna, prices["LUNAUSDT"].Price)
+		require.Equal(t, volume, prices["LUNAUSDT"].Volume)
+	})
+
+	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {
+		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
+		require.Error(t, err)
+		require.Equal(t, "osmosisv2 failed to get ticker price for FOO/BAR", err.Error())
+		require.Nil(t, prices)
+	})
+}
+
+func TestOsmosisV2Provider_GetCandlePrices(t *testing.T) {
+	p, err := NewOsmosisV2Provider(
+		context.TODO(),
+		zerolog.Nop(),
+		Endpoint{},
+		types.CurrencyPair{Base: "OSMO", Quote: "ATOM"},
+	)
+	require.NoError(t, err)
+
+	t.Run("valid_request_single_candle", func(t *testing.T) {
+		price := "34.689998626708984000"
+		volume := "2396974.000000000000000000"
+		time := int64(1000000)
+
+		candle := OsmosisV2Candle{
+			Volume:  volume,
+			Close:   price,
+			EndTime: time,
+		}
+
+		p.setCandlePair("OSMO/ATOM", candle)
+
+		prices, err := p.GetCandlePrices(types.CurrencyPair{Base: "OSMO", Quote: "ATOM"})
+		require.NoError(t, err)
+		require.Len(t, prices, 1)
+		require.Equal(t, sdk.MustNewDecFromStr(price), prices["OSMOATOM"][0].Price)
+		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["OSMOATOM"][0].Volume)
+		require.Equal(t, time, prices["OSMOATOM"][0].TimeStamp)
+	})
+
+	t.Run("invalid_request_invalid_candle", func(t *testing.T) {
+		prices, err := p.GetCandlePrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
+		require.EqualError(t, err, "osmosisv2 failed to get candle price for FOO/BAR")
+		require.Nil(t, prices)
+	})
+}
+
+func TestOsmosisV2CurrencyPairToOsmosisV2Pair(t *testing.T) {
+	cp := types.CurrencyPair{Base: "ATOM", Quote: "USDT"}
+	osmosisv2Symbol := currencyPairToOsmosisV2Pair(cp)
+	require.Equal(t, osmosisv2Symbol, "ATOM/USDT")
+}

--- a/oracle/provider/provider.go
+++ b/oracle/provider/provider.go
@@ -3,62 +3,84 @@ package provider
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
+	"strings"
+	"strconv"
 
 	"price-feeder/oracle/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 const (
-	defaultTimeout           = 10 * time.Second
-	defaultReadNewWSMessage  = 50 * time.Millisecond
-	defaultMaxConnectionTime = time.Hour * 23 // should be < 24h
-	defaultReconnectTime     = time.Minute * 20
-	maxReconnectionTries     = 3
-	providerCandlePeriod     = 10 * time.Minute
+	defaultTimeout       = 10 * time.Second
+	providerCandlePeriod = 10 * time.Minute
+
+	ProviderFin		  Name = "fin"
+	ProviderKraken    Name = "kraken"
+	ProviderBinance   Name = "binance"
+	ProviderBinanceUS Name = "binanceus"
+	ProviderOsmosis   Name = "osmosis"
+	ProviderOsmosisV2 Name = "osmosisv2"
+	ProviderHuobi     Name = "huobi"
+	ProviderOkx       Name = "okx"
+	ProviderGate      Name = "gate"
+	ProviderCoinbase  Name = "coinbase"
+	ProviderBitget    Name = "bitget"
+	ProviderMexc      Name = "mexc"
+	ProviderCrypto    Name = "crypto"
+	ProviderMock      Name = "mock"
 )
 
 var ping = []byte("ping")
 
-// Provider defines an interface an exchange price provider must implement.
-type Provider interface {
-	// GetTickerPrices returns the tickerPrices based on the provided pairs.
-	GetTickerPrices(...types.CurrencyPair) (map[string]TickerPrice, error)
+type (
+	// Provider defines an interface an exchange price provider must implement.
+	Provider interface {
+		// GetTickerPrices returns the tickerPrices based on the provided pairs.
+		GetTickerPrices(...types.CurrencyPair) (map[string]types.TickerPrice, error)
 
-	// GetCandlePrices returns the candlePrices based on the provided pairs.
-	GetCandlePrices(...types.CurrencyPair) (map[string][]CandlePrice, error)
+		// GetCandlePrices returns the candlePrices based on the provided pairs.
+		GetCandlePrices(...types.CurrencyPair) (map[string][]types.CandlePrice, error)
 
-	// GetAvailablePairs return all available pairs symbol to susbscribe.
-	GetAvailablePairs() (map[string]struct{}, error)
+		// GetAvailablePairs return all available pairs symbol to subscribe.
+		GetAvailablePairs() (map[string]struct{}, error)
 
-	// SubscribeCurrencyPairs subscribe to ticker and candle channels for all pairs.
-	SubscribeCurrencyPairs(...types.CurrencyPair) error
+		// SubscribeCurrencyPairs sends subscription messages for the new currency
+		// pairs and adds them to the providers subscribed pairs
+		SubscribeCurrencyPairs(...types.CurrencyPair) error
+	}
+
+	// Name name of an oracle provider. Usually it is an exchange
+	// but this can be any provider name that can give token prices
+	// examples.: "binance", "osmosis", "kraken".
+	Name string
+
+	// AggregatedProviderPrices defines a type alias for a map
+	// of provider -> asset -> TickerPrice
+	AggregatedProviderPrices map[Name]map[string]types.TickerPrice
+
+	// AggregatedProviderCandles defines a type alias for a map
+	// of provider -> asset -> []types.CandlePrice
+	AggregatedProviderCandles map[Name]map[string][]types.CandlePrice
+
+	// Endpoint defines an override setting in our config for the
+	// hardcoded rest and websocket api endpoints.
+	Endpoint struct {
+		// Name of the provider, ex. "binance"
+		Name Name `toml:"name"`
+
+		// Rest endpoint for the provider, ex. "https://api1.binance.com"
+		Rest string `toml:"rest"`
+
+		// Websocket endpoint for the provider, ex. "stream.binance.com:9443"
+		Websocket string `toml:"websocket"`
+	}
+)
+
+// String cast provider name to string.
+func (n Name) String() string {
+	return string(n)
 }
-
-// TickerPrice defines price and volume information for a symbol or ticker
-// exchange rate.
-type TickerPrice struct {
-	Price  sdk.Dec // last trade price
-	Volume sdk.Dec // 24h volume
-}
-
-// AggregatedProviderPrices defines a type alias for a map
-// of provider -> asset -> TickerPrice
-type AggregatedProviderPrices map[string]map[string]TickerPrice
-
-// CandlePrice defines price, volume, and time information for an
-// exchange rate.
-type CandlePrice struct {
-	Price     sdk.Dec // last trade price
-	Volume    sdk.Dec // volume
-	TimeStamp int64   // timestamp
-}
-
-// AggregatedProviderCandles defines a type alias for a map
-// of provider -> asset -> []CandlePrice
-type AggregatedProviderCandles map[string]map[string][]CandlePrice
 
 // preventRedirect avoid any redirect in the http.Client the request call
 // will not return an error, but a valid response with redirect response code.
@@ -77,38 +99,22 @@ func newHTTPClientWithTimeout(timeout time.Duration) *http.Client {
 	}
 }
 
-func newTickerPrice(provider, symbol, lastPrice, volume string) (TickerPrice, error) {
-	price, err := sdk.NewDecFromStr(lastPrice)
-	if err != nil {
-		return TickerPrice{}, fmt.Errorf("failed to parse %s price (%s) for %s", provider, lastPrice, symbol)
-	}
-
-	volumeDec, err := sdk.NewDecFromStr(volume)
-	if err != nil {
-		return TickerPrice{}, fmt.Errorf("failed to parse %s volume (%s) for %s", provider, volume, symbol)
-	}
-
-	return TickerPrice{Price: price, Volume: volumeDec}, nil
-}
-
-func newCandlePrice(provider, symbol, lastPrice, volume string, timeStamp int64) (CandlePrice, error) {
-	price, err := sdk.NewDecFromStr(lastPrice)
-	if err != nil {
-		return CandlePrice{}, fmt.Errorf("failed to parse %s price (%s) for %s", provider, lastPrice, symbol)
-	}
-
-	volumeDec, err := sdk.NewDecFromStr(volume)
-	if err != nil {
-		return CandlePrice{}, fmt.Errorf("failed to parse %s volume (%s) for %s", provider, volume, symbol)
-	}
-
-	return CandlePrice{Price: price, Volume: volumeDec, TimeStamp: timeStamp}, nil
-}
-
 // PastUnixTime returns a millisecond timestamp that represents the unix time
 // minus t.
 func PastUnixTime(t time.Duration) int64 {
 	return time.Now().Add(t*-1).Unix() * int64(time.Second/time.Millisecond)
+}
+
+// SecondsToMilli converts seconds to milliseconds for our unix timestamps.
+func SecondsToMilli(t int64) int64 {
+	return t * int64(time.Second/time.Millisecond)
+}
+
+func checkHTTPStatus(resp *http.Response) error {
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	return nil
 }
 
 func strToDec(str string) sdk.Dec {
@@ -120,4 +126,8 @@ func strToDec(str string) sdk.Dec {
 		}
 	}
 	return sdk.MustNewDecFromStr(str)
+}
+
+func floatToDec(f float64) sdk.Dec {
+	return sdk.MustNewDecFromStr(strconv.FormatFloat(f, 'f', -1, 64))
 }

--- a/oracle/provider/telemetry.go
+++ b/oracle/provider/telemetry.go
@@ -1,0 +1,99 @@
+package provider
+
+import (
+	"github.com/armon/go-metrics"
+	"github.com/cosmos/cosmos-sdk/telemetry"
+)
+
+const (
+	MessageTypeCandle = MessageType("candle")
+	MessageTypeTicker = MessageType("ticker")
+	MessageTypeTrade  = MessageType("trade")
+)
+
+type (
+	MessageType string
+)
+
+// String cast provider MessageType to string.
+func (mt MessageType) String() string {
+	return string(mt)
+}
+
+// providerLabel returns a label based on the provider name.
+func providerLabel(n Name) metrics.Label {
+	return metrics.Label{
+		Name:  "provider",
+		Value: n.String(),
+	}
+}
+
+// messageTypeLabel returns a label based on the message type.
+func messageTypeLabel(mt MessageType) metrics.Label {
+	return metrics.Label{
+		Name:  "type",
+		Value: mt.String(),
+	}
+}
+
+// telemetryWebsocketReconnect gives an standard way to add
+// `price_feeder_websocket_reconnect` metric.
+func telemetryWebsocketReconnect(n Name) {
+	telemetry.IncrCounterWithLabels(
+		[]string{
+			"websocket",
+			"reconnect",
+		},
+		1,
+		[]metrics.Label{
+			providerLabel(n),
+		},
+	)
+}
+
+// telemetryWebsocketSubscribeCurrencyPairs gives an standard way to add
+// `price_feeder_websocket_subscribe_currency_pairs{provider="x"}` metric.
+func telemetryWebsocketSubscribeCurrencyPairs(n Name, incr int) {
+	telemetry.IncrCounterWithLabels(
+		[]string{
+			"websocket",
+			"subscribe",
+			"currency_pairs",
+		},
+		float32(incr),
+		[]metrics.Label{
+			providerLabel(n),
+		},
+	)
+}
+
+// telemetryWebsocketMessage gives an standard way to add
+// `price_feeder_websocket_message{type="x", provider="x"}` metric.
+func telemetryWebsocketMessage(n Name, mt MessageType) {
+	telemetry.IncrCounterWithLabels(
+		[]string{
+			"websocket",
+			"message",
+		},
+		1,
+		[]metrics.Label{
+			providerLabel(n),
+			messageTypeLabel(mt),
+		},
+	)
+}
+
+// TelemetryFailure gives an standard way to add
+// `price_feeder_failure_provider{type="x", provider="x"}` metric.
+func TelemetryFailure(n Name, mt MessageType) {
+	telemetry.IncrCounterWithLabels(
+		[]string{
+			"failure",
+		},
+		1,
+		[]metrics.Label{
+			providerLabel(n),
+			messageTypeLabel(mt),
+		},
+	)
+}

--- a/oracle/provider/websocket_controller.go
+++ b/oracle/provider/websocket_controller.go
@@ -1,0 +1,271 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/rs/zerolog"
+	"price-feeder/oracle/types"
+)
+
+const (
+	defaultReadNewWSMessage   = 50 * time.Millisecond
+	defaultMaxConnectionTime  = time.Hour * 23 // should be < 24h
+	defaultPingDuration       = 15 * time.Second
+	disabledPingDuration      = time.Duration(0)
+	startingReconnectDuration = 5 * time.Second
+	maxRetryMultiplier        = 25 // max retry duration: 52m5s
+)
+
+type (
+	MessageHandler func(int, []byte)
+
+	// WebsocketController defines a provider agnostic websocket handler
+	// that manages reconnecting, subscribing, and receiving messages
+	WebsocketController struct {
+		parentCtx           context.Context
+		websocketCtx        context.Context
+		websocketCancelFunc context.CancelFunc
+		providerName        Name
+		websocketURL        url.URL
+		subscriptionMsgs    []interface{}
+		messageHandler      MessageHandler
+		pingDuration        time.Duration
+		pingMessageType     uint
+		logger              zerolog.Logger
+
+		mtx              sync.Mutex
+		client           *websocket.Conn
+		reconnectCounter uint
+	}
+)
+
+// NewWebsocketController does nothing except initialize a new WebsocketController
+// and provider a reminder for what fields need to be passed in.
+func NewWebsocketController(
+	ctx context.Context,
+	providerName Name,
+	websocketURL url.URL,
+	subscriptionMsgs []interface{},
+	messageHandler MessageHandler,
+	pingDuration time.Duration,
+	pingMessageType uint,
+	logger zerolog.Logger,
+) *WebsocketController {
+	return &WebsocketController{
+		parentCtx:        ctx,
+		providerName:     providerName,
+		websocketURL:     websocketURL,
+		subscriptionMsgs: subscriptionMsgs,
+		messageHandler:   messageHandler,
+		pingDuration:     pingDuration,
+		pingMessageType:  pingMessageType,
+		logger:           logger,
+	}
+}
+
+// Start will continuously loop and attempt connecting to the websocket
+// until a successful connection is made. It then starts the ping
+// service and read listener in new go routines and sends subscription
+// messages  using the passed in subscription messages
+func (wsc *WebsocketController) Start() {
+	connectTicker := time.NewTicker(time.Millisecond)
+	defer connectTicker.Stop()
+
+	for {
+		if err := wsc.connect(); err != nil {
+			wsc.logger.Err(err).Send()
+			select {
+			case <-wsc.parentCtx.Done():
+				return
+			case <-connectTicker.C:
+				connectTicker.Reset(wsc.iterateRetryCounter())
+				continue
+			}
+		}
+
+		go wsc.readWebSocket()
+		go wsc.pingLoop()
+
+		if err := wsc.subscribe(wsc.subscriptionMsgs); err != nil {
+			wsc.logger.Err(err).Send()
+			wsc.close()
+			continue
+		}
+		return
+	}
+}
+
+// connect dials the websocket and sets the client to the established connection
+func (wsc *WebsocketController) connect() error {
+	wsc.mtx.Lock()
+	defer wsc.mtx.Unlock()
+
+	wsc.logger.Debug().Msg("connecting to websocket")
+	conn, resp, err := websocket.DefaultDialer.Dial(wsc.websocketURL.String(), nil)
+	if err != nil {
+		return fmt.Errorf(types.ErrWebsocketDial.Error(), wsc.providerName, err)
+	}
+	defer resp.Body.Close()
+	wsc.client = conn
+	wsc.websocketCtx, wsc.websocketCancelFunc = context.WithCancel(wsc.parentCtx)
+	wsc.client.SetPingHandler(wsc.pingHandler)
+	wsc.reconnectCounter = 0
+	return nil
+}
+
+func (wsc *WebsocketController) iterateRetryCounter() time.Duration {
+	if wsc.reconnectCounter < 25 {
+		wsc.reconnectCounter++
+	}
+	multiplier := math.Pow(float64(wsc.reconnectCounter), 2)
+	return startingReconnectDuration * time.Duration(multiplier)
+}
+
+// subscribe sends the WebsocketControllers subscription messages to the websocket
+func (wsc *WebsocketController) subscribe(msgs []interface{}) error {
+	telemetryWebsocketSubscribeCurrencyPairs(wsc.providerName, len(wsc.subscriptionMsgs))
+	for _, jsonMessage := range msgs {
+		if err := wsc.SendJSON(jsonMessage); err != nil {
+			return fmt.Errorf(types.ErrWebsocketSend.Error(), wsc.providerName, err)
+		}
+	}
+	return nil
+}
+
+// AddSubscriptionMsgs immediately sends the new subscription messages and
+// adds them to the subscriptionMsgs array if successful
+func (wsc *WebsocketController) AddSubscriptionMsgs(msgs []interface{}) error {
+	err := wsc.subscribe(msgs)
+	if err != nil {
+		return err
+	}
+	wsc.subscriptionMsgs = append(wsc.subscriptionMsgs, msgs...)
+	return nil
+}
+
+// SendJSON sends a json message to the websocket connection using the Websocket
+// Controller mutex to ensure multiple writes do not happen at once
+func (wsc *WebsocketController) SendJSON(msg interface{}) error {
+	wsc.mtx.Lock()
+	defer wsc.mtx.Unlock()
+
+	if wsc.client == nil {
+		return fmt.Errorf("unable to send JSON on a closed connection")
+	}
+	wsc.logger.Debug().Interface("msg", msg).Msg("sending websocket message")
+	if err := wsc.client.WriteJSON(msg); err != nil {
+		return fmt.Errorf(types.ErrWebsocketSend.Error(), wsc.providerName, err)
+	}
+	return nil
+}
+
+// ping sends a ping to the server every defaultPingDuration
+func (wsc *WebsocketController) pingLoop() {
+	if wsc.pingDuration == disabledPingDuration {
+		return // disable ping loop if disabledPingDuration
+	}
+	pingTicker := time.NewTicker(wsc.pingDuration)
+	defer pingTicker.Stop()
+
+	for {
+		err := wsc.ping()
+		if err != nil {
+			return
+		}
+		select {
+		case <-wsc.websocketCtx.Done():
+			return
+		case <-pingTicker.C:
+			continue
+		}
+	}
+}
+
+func (wsc *WebsocketController) ping() error {
+	wsc.mtx.Lock()
+	defer wsc.mtx.Unlock()
+
+	if wsc.client == nil {
+		return fmt.Errorf("unable to ping closed connection")
+	}
+	err := wsc.client.WriteMessage(int(wsc.pingMessageType), ping)
+	if err != nil {
+		wsc.logger.Err(fmt.Errorf(types.ErrWebsocketSend.Error(), wsc.providerName, err)).Send()
+	}
+	return err
+}
+
+// readWebSocket continuously reads from the websocket and relays messages
+// to the passed in messageHandler. On websocket error this function
+// terminates and starts the reconnect process.
+// Some providers (Binance) will only allow a valid connection for 24 hours
+// so we manually disconnect and reconnect every 23 hours (defaultMaxConnectionTime)
+func (wsc *WebsocketController) readWebSocket() {
+	reconnectTicker := time.NewTicker(defaultMaxConnectionTime)
+	defer reconnectTicker.Stop()
+
+	for {
+		select {
+		case <-wsc.websocketCtx.Done():
+			wsc.close()
+			return
+		case <-time.After(defaultReadNewWSMessage):
+			messageType, bz, err := wsc.client.ReadMessage()
+			if err != nil {
+				wsc.logger.Err(fmt.Errorf(types.ErrWebsocketRead.Error(), wsc.providerName, err)).Send()
+				wsc.reconnect()
+				return
+			}
+			wsc.readSuccess(messageType, bz)
+		case <-reconnectTicker.C:
+			wsc.reconnect()
+			return
+		}
+	}
+}
+
+func (wsc *WebsocketController) readSuccess(messageType int, bz []byte) {
+	if len(bz) == 0 {
+		return
+	}
+	// mexc and bitget do not send a valid pong response code so check for it here
+	if string(bz) == "pong" {
+		return
+	}
+	wsc.messageHandler(messageType, bz)
+}
+
+// close sends a close message to the websocket and sets the client to nil
+func (wsc *WebsocketController) close() {
+	wsc.mtx.Lock()
+	defer wsc.mtx.Unlock()
+
+	wsc.logger.Debug().Msg("closing websocket")
+	wsc.websocketCancelFunc()
+	if err := wsc.client.Close(); err != nil {
+		wsc.logger.Err(fmt.Errorf(types.ErrWebsocketClose.Error(), wsc.providerName, err)).Send()
+	}
+	wsc.client = nil
+}
+
+// reconnect closes the current websocket and starts a new connection process
+func (wsc *WebsocketController) reconnect() {
+	wsc.close()
+	go wsc.Start()
+	telemetryWebsocketReconnect(wsc.providerName)
+}
+
+// pingHandler is called by the websocket library whenever a ping message is received
+// and responds with a pong message to the server
+func (wsc *WebsocketController) pingHandler(appData string) error {
+	if err := wsc.client.WriteMessage(websocket.PongMessage, []byte("pong")); err != nil {
+		wsc.logger.Error().Err(err).Msg("error sending pong")
+	}
+	return nil
+}

--- a/oracle/provider/websocket_controller_test.go
+++ b/oracle/provider/websocket_controller_test.go
@@ -1,0 +1,58 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+type TestProvider struct {
+	handlerCalled bool
+}
+
+func (mp *TestProvider) messageHandler(messageType int, bz []byte) {
+	mp.handlerCalled = true
+}
+
+func TestWebsocketController_readSuccess(t *testing.T) {
+	testCases := []struct {
+		name                     string
+		messageType              int
+		bz                       []byte
+		shouldCallMessageHandler bool
+	}{
+		{
+			"message length is zero",
+			1,
+			[]byte{},
+			false,
+		},
+		{
+			"message is a pong",
+			1,
+			[]byte("pong"),
+			false,
+		},
+		{
+			"is a valid message for the messageHandler",
+			1,
+			[]byte("asdf"),
+			true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			provider := TestProvider{}
+			mockClient := new(websocket.Conn)
+			c := &WebsocketController{
+				providerName:   ProviderMock,
+				messageHandler: provider.messageHandler,
+				client:         mockClient,
+			}
+			c.readSuccess(testCase.messageType, testCase.bz)
+			require.Equal(t, provider.handlerCalled, testCase.shouldCallMessageHandler)
+		})
+	}
+}

--- a/oracle/types/candle_price.go
+++ b/oracle/types/candle_price.go
@@ -1,0 +1,29 @@
+package types
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// CandlePrice defines price, volume, and time information for an exchange rate.
+type CandlePrice struct {
+	Price     sdk.Dec // last trade price
+	Volume    sdk.Dec // volume
+	TimeStamp int64   // timestamp
+}
+
+// NewCandlePrice parses the lastPrice and volume to a decimal and returns a CandlePrice
+func NewCandlePrice(provider, symbol, lastPrice, volume string, timeStamp int64) (CandlePrice, error) {
+	price, err := sdk.NewDecFromStr(lastPrice)
+	if err != nil {
+		return CandlePrice{}, fmt.Errorf("failed to parse %s price (%s) for %s: %w", provider, lastPrice, symbol, err)
+	}
+
+	volumeDec, err := sdk.NewDecFromStr(volume)
+	if err != nil {
+		return CandlePrice{}, fmt.Errorf("failed to parse %s volume (%s) for %s: %w", provider, volume, symbol, err)
+	}
+
+	return CandlePrice{Price: price, Volume: volumeDec, TimeStamp: timeStamp}, nil
+}

--- a/oracle/types/candle_price_test.go
+++ b/oracle/types/candle_price_test.go
@@ -1,0 +1,37 @@
+package types
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCandlePrice(t *testing.T) {
+	price := "105473.43"
+	volume := "48394"
+	timeStamp := int64(1257894000)
+
+	t.Run("when the inputs are valid", func(t *testing.T) {
+		candlePrice, err := NewCandlePrice("binance", "BTC", price, volume, timeStamp)
+		require.Nil(t, err, "expected the returned error to be nil")
+
+		parsedPrice, _ := sdk.NewDecFromStr(price)
+		require.Equal(t, candlePrice.Price, parsedPrice)
+
+		parsedVolume, _ := sdk.NewDecFromStr(volume)
+		require.Equal(t, candlePrice.Volume, parsedVolume)
+
+		require.Equal(t, candlePrice.TimeStamp, timeStamp)
+	})
+
+	t.Run("when the lastPrice input is invalid", func(t *testing.T) {
+		_, err := NewCandlePrice("binance", "BTC", "bad_price", volume, timeStamp)
+		require.NotNil(t, err, "expected the returned error to not be nil")
+	})
+
+	t.Run("when the volume input is invalid", func(t *testing.T) {
+		_, err := NewCandlePrice("binance", "BTC", price, "bad_volume", timeStamp)
+		require.NotNil(t, err, "expected the returned error to not be nil")
+	})
+}

--- a/oracle/types/errors.go
+++ b/oracle/types/errors.go
@@ -1,0 +1,20 @@
+package types
+
+import (
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+const ModuleName = "price-feeder"
+
+// Price feeder errors
+var (
+	ErrProviderConnection  = sdkerrors.Register(ModuleName, 1, "provider connection")
+	ErrMissingExchangeRate = sdkerrors.Register(ModuleName, 2, "missing exchange rate for %s")
+	ErrTickerNotFound      = sdkerrors.Register(ModuleName, 3, "%s failed to get ticker price for %s")
+	ErrCandleNotFound      = sdkerrors.Register(ModuleName, 4, "%s failed to get candle price for %s")
+
+	ErrWebsocketDial  = sdkerrors.Register(ModuleName, 5, "error connecting to %s websocket: %w")
+	ErrWebsocketClose = sdkerrors.Register(ModuleName, 6, "error closing %s websocket: %w")
+	ErrWebsocketSend  = sdkerrors.Register(ModuleName, 7, "error sending to %s websocket: %w")
+	ErrWebsocketRead  = sdkerrors.Register(ModuleName, 8, "error reading from %s websocket: %w")
+)

--- a/oracle/types/ticker_price.go
+++ b/oracle/types/ticker_price.go
@@ -1,0 +1,28 @@
+package types
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// TickerPrice defines price and volume information for a symbol or ticker exchange rate.
+type TickerPrice struct {
+	Price  sdk.Dec // last trade price
+	Volume sdk.Dec // 24h volume
+}
+
+// NewTickerPrice parses the lastPrice and volume to a decimal and returns a TickerPrice
+func NewTickerPrice(provider, symbol, lastPrice, volume string) (TickerPrice, error) {
+	price, err := sdk.NewDecFromStr(lastPrice)
+	if err != nil {
+		return TickerPrice{}, fmt.Errorf("failed to parse %s price (%s) for %s: %w", provider, lastPrice, symbol, err)
+	}
+
+	volumeDec, err := sdk.NewDecFromStr(volume)
+	if err != nil {
+		return TickerPrice{}, fmt.Errorf("failed to parse %s volume (%s) for %s: %w", provider, volume, symbol, err)
+	}
+
+	return TickerPrice{Price: price, Volume: volumeDec}, nil
+}

--- a/oracle/types/ticker_price_test.go
+++ b/oracle/types/ticker_price_test.go
@@ -1,0 +1,34 @@
+package types
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTicketPrice(t *testing.T) {
+	price := "105473.43"
+	volume := "48394"
+
+	t.Run("when the inputs are valid", func(t *testing.T) {
+		tickerPrice, err := NewTickerPrice("binance", "BTC", price, volume)
+		require.Nil(t, err, "expected the returned error to be nil")
+
+		parsedPrice, _ := sdk.NewDecFromStr(price)
+		require.Equal(t, tickerPrice.Price, parsedPrice)
+
+		parsedVolume, _ := sdk.NewDecFromStr(volume)
+		require.Equal(t, tickerPrice.Volume, parsedVolume)
+	})
+
+	t.Run("when the lastPrice input is invalid", func(t *testing.T) {
+		_, err := NewTickerPrice("binance", "BTC", "bad_price", volume)
+		require.NotNil(t, err, "expected the returned error to not be nil")
+	})
+
+	t.Run("when the volume input is invalid", func(t *testing.T) {
+		_, err := NewTickerPrice("binance", "BTC", price, "bad_volume")
+		require.NotNil(t, err, "expected the returned error to not be nil")
+	})
+}

--- a/oracle/util.go
+++ b/oracle/util.go
@@ -82,6 +82,9 @@ func ComputeTVWAP(prices provider.AggregatedProviderCandles) (map[string]sdk.Dec
 	for _, providerPrices := range prices {
 		for base := range providerPrices {
 			cp := providerPrices[base]
+			if len(cp) == 0 {
+				continue
+			}
 
 			if _, ok := weightedPrices[base]; !ok {
 				weightedPrices[base] = sdk.ZeroDec()
@@ -126,7 +129,7 @@ func ComputeTVWAP(prices provider.AggregatedProviderCandles) (map[string]sdk.Dec
 // StandardDeviation returns maps of the standard deviations and means of assets.
 // Will skip calculating for an asset if there are less than 3 prices.
 func StandardDeviation(
-	prices map[string]map[string]sdk.Dec,
+	prices map[provider.Name]map[string]sdk.Dec,
 ) (map[string]sdk.Dec, map[string]sdk.Dec, error) {
 	var (
 		deviations = make(map[string]sdk.Dec)

--- a/oracle/util_test.go
+++ b/oracle/util_test.go
@@ -3,9 +3,9 @@ package oracle_test
 import (
 	"testing"
 
-	"price-feeder/config"
 	"price-feeder/oracle"
 	"price-feeder/oracle/provider"
+	"price-feeder/oracle/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
@@ -13,11 +13,11 @@ import (
 
 func TestComputeVWAP(t *testing.T) {
 	testCases := map[string]struct {
-		prices   map[string]map[string]provider.TickerPrice
+		prices   map[provider.Name]map[string]types.TickerPrice
 		expected map[string]sdk.Dec
 	}{
 		"empty prices": {
-			prices:   make(map[string]map[string]provider.TickerPrice),
+			prices:   make(map[provider.Name]map[string]types.TickerPrice),
 			expected: make(map[string]sdk.Dec),
 		},
 		"nil prices": {
@@ -25,33 +25,33 @@ func TestComputeVWAP(t *testing.T) {
 			expected: make(map[string]sdk.Dec),
 		},
 		"non empty prices": {
-			prices: map[string]map[string]provider.TickerPrice{
-				config.ProviderBinance: {
-					"ATOM": provider.TickerPrice{
+			prices: map[provider.Name]map[string]types.TickerPrice{
+				provider.ProviderBinance: {
+					"ATOM": types.TickerPrice{
 						Price:  sdk.MustNewDecFromStr("28.21000000"),
 						Volume: sdk.MustNewDecFromStr("2749102.78000000"),
 					},
-					"UMEE": provider.TickerPrice{
+					"UMEE": types.TickerPrice{
 						Price:  sdk.MustNewDecFromStr("1.13000000"),
 						Volume: sdk.MustNewDecFromStr("249102.38000000"),
 					},
-					"LUNA": provider.TickerPrice{
+					"LUNA": types.TickerPrice{
 						Price:  sdk.MustNewDecFromStr("64.87000000"),
 						Volume: sdk.MustNewDecFromStr("7854934.69000000"),
 					},
 				},
-				config.ProviderKraken: {
-					"ATOM": provider.TickerPrice{
+				provider.ProviderKraken: {
+					"ATOM": types.TickerPrice{
 						Price:  sdk.MustNewDecFromStr("28.268700"),
 						Volume: sdk.MustNewDecFromStr("178277.53314385"),
 					},
-					"LUNA": provider.TickerPrice{
+					"LUNA": types.TickerPrice{
 						Price:  sdk.MustNewDecFromStr("64.87853000"),
 						Volume: sdk.MustNewDecFromStr("458917.46353577"),
 					},
 				},
 				"FOO": {
-					"ATOM": provider.TickerPrice{
+					"ATOM": types.TickerPrice{
 						Price:  sdk.MustNewDecFromStr("28.168700"),
 						Volume: sdk.MustNewDecFromStr("4749102.53314385"),
 					},
@@ -86,11 +86,11 @@ func TestStandardDeviation(t *testing.T) {
 		deviation sdk.Dec
 	}
 	testCases := map[string]struct {
-		prices   map[string]map[string]sdk.Dec
+		prices   map[provider.Name]map[string]sdk.Dec
 		expected map[string]deviation
 	}{
 		"empty prices": {
-			prices:   make(map[string]map[string]sdk.Dec),
+			prices:   make(map[provider.Name]map[string]sdk.Dec),
 			expected: map[string]deviation{},
 		},
 		"nil prices": {
@@ -98,13 +98,13 @@ func TestStandardDeviation(t *testing.T) {
 			expected: map[string]deviation{},
 		},
 		"not enough prices": {
-			prices: map[string]map[string]sdk.Dec{
-				config.ProviderBinance: {
+			prices: map[provider.Name]map[string]sdk.Dec{
+				provider.ProviderBinance: {
 					"ATOM": sdk.MustNewDecFromStr("28.21000000"),
 					"UMEE": sdk.MustNewDecFromStr("1.13000000"),
 					"LUNA": sdk.MustNewDecFromStr("64.87000000"),
 				},
-				config.ProviderKraken: {
+				provider.ProviderKraken: {
 					"ATOM": sdk.MustNewDecFromStr("28.23000000"),
 					"UMEE": sdk.MustNewDecFromStr("1.13050000"),
 					"LUNA": sdk.MustNewDecFromStr("64.85000000"),
@@ -113,17 +113,17 @@ func TestStandardDeviation(t *testing.T) {
 			expected: map[string]deviation{},
 		},
 		"some prices": {
-			prices: map[string]map[string]sdk.Dec{
-				config.ProviderBinance: {
+			prices: map[provider.Name]map[string]sdk.Dec{
+				provider.ProviderBinance: {
 					"ATOM": sdk.MustNewDecFromStr("28.21000000"),
 					"UMEE": sdk.MustNewDecFromStr("1.13000000"),
 					"LUNA": sdk.MustNewDecFromStr("64.87000000"),
 				},
-				config.ProviderKraken: {
+				provider.ProviderKraken: {
 					"ATOM": sdk.MustNewDecFromStr("28.23000000"),
 					"UMEE": sdk.MustNewDecFromStr("1.13050000"),
 				},
-				config.ProviderOsmosis: {
+				provider.ProviderOsmosis: {
 					"ATOM": sdk.MustNewDecFromStr("28.40000000"),
 					"UMEE": sdk.MustNewDecFromStr("1.14000000"),
 					"LUNA": sdk.MustNewDecFromStr("64.10000000"),
@@ -142,19 +142,19 @@ func TestStandardDeviation(t *testing.T) {
 		},
 
 		"non empty prices": {
-			prices: map[string]map[string]sdk.Dec{
-				config.ProviderBinance: {
+			prices: map[provider.Name]map[string]sdk.Dec{
+				provider.ProviderBinance: {
 					"ATOM": sdk.MustNewDecFromStr("28.21000000"),
 
 					"UMEE": sdk.MustNewDecFromStr("1.13000000"),
 					"LUNA": sdk.MustNewDecFromStr("64.87000000"),
 				},
-				config.ProviderKraken: {
+				provider.ProviderKraken: {
 					"ATOM": sdk.MustNewDecFromStr("28.23000000"),
 					"UMEE": sdk.MustNewDecFromStr("1.13050000"),
 					"LUNA": sdk.MustNewDecFromStr("64.85000000"),
 				},
-				config.ProviderOsmosis: {
+				provider.ProviderOsmosis: {
 					"ATOM": sdk.MustNewDecFromStr("28.40000000"),
 					"UMEE": sdk.MustNewDecFromStr("1.14000000"),
 					"LUNA": sdk.MustNewDecFromStr("64.10000000"),


### PR DESCRIPTION
This PR includes several changes to improve the price feeder's reliability and some refactors that will make adding new providers much easier.
- Integrated a few updates to the providers from the Umee upstream; they did some great work to refactor websocket providers to share code and added some new options.
- Rewrote the chain height logic to poll the RPC at a configurable interval instead of subscribing to the NewBlock event with a websocket since that method proved unreliable.
- Added a `provider_min_override` option which disables the check requiring at least 3 providers configured.
- Modified the Binance websocket to subscribe to all pairs in a single message -- fixes regression introduced by the Umee updates which prevented subscribing to more than 2 pairs at a time.
