### PR TITLE
update kraken provider to support LUNA/LUNC

### DIFF
--- a/oracle/provider/kraken_test.go
+++ b/oracle/provider/kraken_test.go
@@ -77,22 +77,14 @@ func TestKrakenProvider_GetTickerPrices(t *testing.T) {
 
 func TestKrakenPairToCurrencyPairSymbol(t *testing.T) {
 	cp := types.CurrencyPair{Base: "ATOM", Quote: "USDT"}
-	currencyPairSymbol := krakenPairToCurrencyPairSymbol("ATOM/USDT")
-	require.Equal(t, cp.String(), currencyPairSymbol)
+	currencyPair := krakenPairToCurrencyPair("ATOM/USDT")
+	require.Equal(t, cp, currencyPair)
 }
 
 func TestKrakenCurrencyPairToKrakenPair(t *testing.T) {
 	cp := types.CurrencyPair{Base: "ATOM", Quote: "USDT"}
 	krakenSymbol := currencyPairToKrakenPair(cp)
 	require.Equal(t, krakenSymbol, "ATOM/USDT")
-}
-
-func TestNormalizeKrakenBTCPair(t *testing.T) {
-	btcSymbol := normalizeKrakenBTCPair("XBT/USDT")
-	require.Equal(t, btcSymbol, "BTC/USDT")
-
-	atomSymbol := normalizeKrakenBTCPair("ATOM/USDT")
-	require.Equal(t, atomSymbol, "ATOM/USDT")
 }
 
 func TestKrakenProvider_getSubscriptionMsgs(t *testing.T) {


### PR DESCRIPTION
Kraken expects LUNA2 instead of LUNA and LUNA instead of LUNC. This includes translations for both pairs and integrates the existing one for BTC -> XBT.