### PR TITLE
Stabilize price streams

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -54,6 +54,7 @@ var (
 		provider.ProviderMexc:      {},
 		provider.ProviderCrypto:    {},
 		provider.ProviderMock:      {},
+		provider.ProviderStride:    {},
 	}
 
 	// maxDeviationThreshold is the maxmimum allowed amount of standard

--- a/oracle/filter.go
+++ b/oracle/filter.go
@@ -40,7 +40,7 @@ func FilterStaleTickers(
 				// filteredPrices[providerName][base] = tp
 			} else {
 				diff := float64(now-tp.Time) / 1000
-				logger.Warn().
+				logger.Debug().
 					Str("provider", providerName.String()).
 					Str("asset", base).
 					Float64("age", diff).

--- a/oracle/filter.go
+++ b/oracle/filter.go
@@ -99,13 +99,13 @@ func FilterTickerDeviations(
 				p[base] = tp
 			} else {
 				telemetry.IncrCounter(1, "failure", "provider", "type", "ticker")
-				logger.Warn().
+				logger.Debug().
 					Str("base", base).
 					Str("provider", providerName.String()).
 					Str("price", tp.Price.String()).
 					Str("mean", means[base].String()).
 					Str("margin", d.Mul(t).String()).
-					Msg("provider deviating from other prices")
+					Msg("deviating price")
 			}
 		}
 	}

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -536,6 +536,9 @@ func NewProvider(
 	case provider.ProviderFin:
 		return provider.NewFinProvider(endpoint), nil
 
+	case provider.ProviderStride:
+		return provider.NewStrideProvider(endpoint), nil
+
 	}
 
 	return nil, fmt.Errorf("provider %s not found", providerName)

--- a/oracle/provider/coinbase_test.go
+++ b/oracle/provider/coinbase_test.go
@@ -25,8 +25,8 @@ func TestCoinbaseProvider_GetTickerPrices(t *testing.T) {
 		lastPrice := "34.69000000"
 		volume := "2396974.02000000"
 
-		tickerMap := map[string]CoinbaseTicker{}
-		tickerMap["ATOM-USDT"] = CoinbaseTicker{
+		tickerMap := map[string]CoinbaseWsTickerMsg{}
+		tickerMap["ATOM-USDT"] = CoinbaseWsTickerMsg{
 			Price:  lastPrice,
 			Volume: volume,
 		}
@@ -45,13 +45,13 @@ func TestCoinbaseProvider_GetTickerPrices(t *testing.T) {
 		lastPriceUmee := "41.35000000"
 		volume := "2396974.02000000"
 
-		tickerMap := map[string]CoinbaseTicker{}
-		tickerMap["ATOM-USDT"] = CoinbaseTicker{
+		tickerMap := map[string]CoinbaseWsTickerMsg{}
+		tickerMap["ATOM-USDT"] = CoinbaseWsTickerMsg{
 			Price:  lastPriceAtom,
 			Volume: volume,
 		}
 
-		tickerMap["UMEE-USDT"] = CoinbaseTicker{
+		tickerMap["UMEE-USDT"] = CoinbaseWsTickerMsg{
 			Price:  lastPriceUmee,
 			Volume: volume,
 		}

--- a/oracle/provider/mexc.go
+++ b/oracle/provider/mexc.go
@@ -46,6 +46,11 @@ type (
 		Params []string `json:"params"`
 	}
 
+	MexcWsGenericMsg struct {
+		Code    int64  `json:"code"`
+		Message string `json:"msg"`
+	}
+
 	MexcWsCandleMsg struct {
 		Symbol string           `json:"s"`
 		Data   MexcWsCandleData `json:"d"`
@@ -232,14 +237,20 @@ func (p *MexcProvider) GetTickerPrice(cp types.CurrencyPair) (types.TickerPrice,
 
 func (p *MexcProvider) messageReceived(messageType int, bz []byte) {
 	var (
-		candleMsg MexcWsCandleMsg
-		candleErr error
+		candleMsg  MexcWsCandleMsg
+		candleErr  error
+		genericMsg MexcWsGenericMsg
 	)
 
 	candleErr = json.Unmarshal(bz, &candleMsg)
 	if candleErr == nil && candleMsg.Symbol != "" {
 		p.setTickerPrice(candleMsg)
 		telemetryWebsocketMessage(ProviderMexc, MessageTypeTicker)
+		return
+	}
+
+	err := json.Unmarshal(bz, &genericMsg)
+	if err == nil && genericMsg.Code == 0 {
 		return
 	}
 

--- a/oracle/provider/mexc.go
+++ b/oracle/provider/mexc.go
@@ -4,22 +4,22 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync"
-	"time"
 
 	"price-feeder/oracle/types"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
 )
 
 const (
 	mexcWSHost   = "wbs.mexc.com"
-	mexcWSPath   = "/raw/ws"
-	mexcRestHost = "https://www.mexc.com"
+	mexcWSPath   = "/ws"
+	mexcRestHost = "https://api.mexc.com"
 	mexcRestPath = "/open/api/v2/market/ticker"
 )
 
@@ -37,29 +37,38 @@ type (
 		logger          zerolog.Logger
 		mtx             sync.RWMutex
 		endpoints       Endpoint
-		tickers         map[string]types.TickerPrice  // Symbol => TickerPrice
+		tickers         map[string]MexcTicker         // Symbol => TickerPrice
 		subscribedPairs map[string]types.CurrencyPair // Symbol => types.CurrencyPair
 	}
 
-	// MexcTickerResponse is the ticker price response object.
-	MexcTickerResponse struct {
-		Symbol map[string]MexcTicker `json:"data"` // e.x. ATOM_USDT
+	MexcWsSubscriptionMsg struct {
+		Method string   `json:"method"`
+		Params []string `json:"params"`
+	}
+
+	MexcWsCandleMsg struct {
+		Symbol string           `json:"s"`
+		Data   MexcWsCandleData `json:"d"`
+		Time   int64            `json:"t"`
+	}
+
+	MexcWsCandleData struct {
+		Candle MexcWsCandle `json:"k"`
+	}
+
+	MexcWsCandle struct {
+		Close float64 `json:"c"`
+	}
+
+	MexcRestTickerResponse struct {
+		Symbol string `json:"symbol"`
+		Volume string `json:"volume"`
 	}
 
 	MexcTicker struct {
-		LastPrice float64 `json:"p"` // Last price ex.: 0.0025
-		Volume    float64 `json:"v"` // Total traded base asset volume ex.: 1000
-	}
-
-	// MexcTickerSubscription Msg to subscribe all the ticker channels.
-	MexcTickerSubscription struct {
-		OP string `json:"op"` // kline
-	}
-
-	// MexcPairSummary defines the response structure for a Mexc pair
-	// summary.
-	MexcPairSummary struct {
-		Symbol string `json:"symbol"`
+		Price  float64
+		Volume string
+		Time   int64
 	}
 )
 
@@ -88,7 +97,7 @@ func NewMexcProvider(
 	provider := &MexcProvider{
 		logger:          mexcLogger,
 		endpoints:       endpoints,
-		tickers:         map[string]types.TickerPrice{},
+		tickers:         map[string]MexcTicker{},
 		subscribedPairs: map[string]types.CurrencyPair{},
 	}
 
@@ -112,8 +121,15 @@ func NewMexcProvider(
 func (p *MexcProvider) GetSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {
 	subscriptionMsgs := make([]interface{}, 1)
 
-	subscriptionMsgs[0] = MexcTickerSubscription{
-		OP: "sub.overview",
+	params := make([]string, len(cps))
+
+	for i, cp := range cps {
+		params[i] = "spot@public.kline.v3.api@" + cp.String() + "@Min15"
+	}
+
+	subscriptionMsgs[0] = MexcWsSubscriptionMsg{
+		Method: "SUBSCRIPTION",
+		Params: params,
 	}
 
 	return subscriptionMsgs
@@ -146,6 +162,49 @@ func (p *MexcProvider) SendSubscriptionMsgs(msgs []interface{}) error {
 
 // GetTickerPrices returns the tickerPrices based on the provided pairs.
 func (p *MexcProvider) GetTickerPrices(cps ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
+	go func() {
+		for _, cp := range cps {
+			client := &http.Client{}
+
+			req, err := http.NewRequest(
+				"GET", p.endpoints.Rest+"/api/v3/ticker/24hr", nil,
+			)
+			if err != nil {
+				p.logger.Err(err)
+				continue
+			}
+
+			query := req.URL.Query()
+			query.Add("symbol", cp.String())
+			req.URL.RawQuery = query.Encode()
+
+			resp, err := client.Do(req)
+			if err != nil {
+				p.logger.Err(err)
+				continue
+			}
+			defer resp.Body.Close()
+
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				p.logger.Err(err)
+				continue
+			}
+
+			var tickerResponse MexcRestTickerResponse
+
+			err = json.Unmarshal(body, &tickerResponse)
+			if err != nil {
+				p.logger.Err(err)
+				continue
+			}
+
+			p.setTickerVolume(tickerResponse.Symbol, tickerResponse.Volume)
+		}
+
+		p.logger.Info().Msg("Done updating volumes")
+	}()
+
 	return getTickerPrices(p, cps)
 }
 
@@ -153,7 +212,7 @@ func (p *MexcProvider) GetTickerPrice(cp types.CurrencyPair) (types.TickerPrice,
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
-	key := cp.Join("_")
+	key := cp.String()
 
 	ticker, ok := p.tickers[key]
 	if !ok {
@@ -164,66 +223,63 @@ func (p *MexcProvider) GetTickerPrice(cp types.CurrencyPair) (types.TickerPrice,
 		)
 	}
 
-	return ticker, nil
+	return types.TickerPrice{
+		Price:  sdk.MustNewDecFromStr(fmt.Sprintf("%f", ticker.Price)),
+		Volume: sdk.MustNewDecFromStr(ticker.Volume),
+		Time:   ticker.Time,
+	}, nil
 }
 
 func (p *MexcProvider) messageReceived(messageType int, bz []byte) {
 	var (
-		tickerResp MexcTickerResponse
-		tickerErr  error
+		candleMsg MexcWsCandleMsg
+		candleErr error
 	)
 
-	tickerErr = json.Unmarshal(bz, &tickerResp)
-	for _, cp := range p.subscribedPairs {
-		mexcPair := cp.Join("_")
-		if tickerResp.Symbol[mexcPair].LastPrice != 0 {
-			p.setTickerPair(
-				mexcPair,
-				tickerResp.Symbol[mexcPair],
-			)
-			telemetryWebsocketMessage(ProviderMexc, MessageTypeTicker)
-			return
-		}
+	candleErr = json.Unmarshal(bz, &candleMsg)
+	if candleErr == nil && candleMsg.Symbol != "" {
+		p.setTickerPrice(candleMsg)
+		telemetryWebsocketMessage(ProviderMexc, MessageTypeTicker)
+		return
 	}
 
-	if tickerErr != nil {
-		p.logger.Error().
-			Int("length", len(bz)).
-			AnErr("ticker", tickerErr).
-			Str("msg", string(bz)).
-			Msg("mexc: Error on receive message")
-	}
+	p.logger.Error().
+		Int("length", len(bz)).
+		AnErr("candle", candleErr).
+		Str("msg", string(bz)).
+		Msg("mexc: Error on receive message")
 }
 
-func (p *MexcProvider) setTickerPair(symbol string, ticker MexcTicker) {
+func (p *MexcProvider) setTickerVolume(symbol string, volume string) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 
-	p.tickers[symbol] = types.TickerPrice{
-		Price:  floatToDec(ticker.LastPrice),
-		Volume: floatToDec(ticker.Volume),
-		Time:   time.Now().UnixMilli(),
+	if ticker, ok := p.tickers[symbol]; ok {
+		ticker.Volume = volume
+		p.tickers[symbol] = ticker
+	}
+}
+
+func (p *MexcProvider) setTickerPrice(candleMsg MexcWsCandleMsg) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	if ticker, ok := p.tickers[candleMsg.Symbol]; ok {
+		ticker.Price = candleMsg.Data.Candle.Close
+		ticker.Time = candleMsg.Time
+		p.tickers[candleMsg.Symbol] = ticker
+	} else {
+		p.tickers[candleMsg.Symbol] = MexcTicker{
+			Price:  candleMsg.Data.Candle.Close,
+			Volume: "0",
+			Time:   candleMsg.Time,
+		}
 	}
 }
 
 // GetAvailablePairs returns all pairs to which the provider can subscribe.
 // ex.: map["ATOMUSDT" => {}, "UMEEUSDC" => {}].
 func (p *MexcProvider) GetAvailablePairs() (map[string]struct{}, error) {
-	resp, err := http.Get(p.endpoints.Rest + mexcRestPath)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var pairsSummary []MexcPairSummary
-	if err := json.NewDecoder(resp.Body).Decode(&pairsSummary); err != nil {
-		return nil, err
-	}
-
-	availablePairs := make(map[string]struct{}, len(pairsSummary))
-	for _, pairName := range pairsSummary {
-		availablePairs[strings.ToUpper(pairName.Symbol)] = struct{}{}
-	}
-
-	return availablePairs, nil
+	// not used yet, so skipping this unless needed
+	return make(map[string]struct{}, 0), nil
 }

--- a/oracle/provider/okx.go
+++ b/oracle/provider/okx.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"sync"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
 
@@ -35,50 +35,40 @@ type (
 		logger          zerolog.Logger
 		mtx             sync.RWMutex
 		endpoints       Endpoint
-		tickers         map[string]OkxTickerPair      // InstId => OkxTickerPair
+		tickers         map[string]OkxTicker          // InstId => OkxTickerPair
 		subscribedPairs map[string]types.CurrencyPair // Symbol => types.CurrencyPair
 	}
 
-	// OkxInstId defines the id Symbol of an pair.
-	OkxInstID struct {
-		InstID string `json:"instId"` // Instrument ID ex.: BTC-USDT
-	}
-
-	// OkxTickerPair defines a ticker pair of Okx.
-	OkxTickerPair struct {
-		OkxInstID
-		Last   string `json:"last"`   // Last traded price ex.: 43508.9
-		Vol24h string `json:"vol24h"` // 24h trading volume ex.: 11159.87127845
-		TS     string `json:"ts"`     // Timestamp
-	}
-
-	// OkxInst defines the structure containing ID information for the OkxResponses.
-	OkxID struct {
-		OkxInstID
-		Channel string `json:"channel"`
-	}
-
-	// OkxTickerResponse defines the response structure of a Okx ticker request.
-	OkxTickerResponse struct {
-		Data []OkxTickerPair `json:"data"`
-		ID   OkxID           `json:"arg"`
+	// OkxSubscriptionMsg Message to subscribe/unsubscribe with N Topics.
+	OkxWsSubscriptionMsg struct {
+		Op   string                   `json:"op"` // Operation ex.: subscribe
+		Args []OkxWsSubscriptionTopic `json:"args"`
 	}
 
 	// OkxSubscriptionTopic Topic with the ticker to be subscribed/unsubscribed.
-	OkxSubscriptionTopic struct {
+	OkxWsSubscriptionTopic struct {
 		Channel string `json:"channel"` // Channel name ex.: tickers
 		InstID  string `json:"instId"`  // Instrument ID ex.: BTC-USDT
 	}
 
-	// OkxSubscriptionMsg Message to subscribe/unsubscribe with N Topics.
-	OkxSubscriptionMsg struct {
-		Op   string                 `json:"op"` // Operation ex.: subscribe
-		Args []OkxSubscriptionTopic `json:"args"`
+	OkxWsCandleMsg struct {
+		Args OkxWsSubscriptionTopic `json:"arg"`
+		Data [][9]string            `json:"data"`
 	}
 
-	// OkxPairsSummary defines the response structure for an Okx pairs summary.
-	OkxPairsSummary struct {
-		Data []OkxInstID `json:"data"`
+	OkxRestTickerResponse struct {
+		Data []OkxRestTicker `json:"data"`
+	}
+
+	OkxRestTicker struct {
+		InstID string `json:"instId"`
+		Volume string `json:"vol24h"`
+	}
+
+	OkxTicker struct {
+		Price  string
+		Volume string
+		Time   string
 	}
 )
 
@@ -108,7 +98,7 @@ func NewOkxProvider(
 	provider := &OkxProvider{
 		logger:          okxLogger,
 		endpoints:       endpoints,
-		tickers:         map[string]OkxTickerPair{},
+		tickers:         map[string]OkxTicker{},
 		subscribedPairs: map[string]types.CurrencyPair{},
 	}
 
@@ -132,16 +122,16 @@ func NewOkxProvider(
 func (p *OkxProvider) GetSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {
 	subscriptionMsgs := make([]interface{}, 1)
 
-	okxTopics := make([]OkxSubscriptionTopic, len(cps))
+	okxTopics := make([]OkxWsSubscriptionTopic, len(cps))
 
 	for i, cp := range cps {
-		okxTopics[i] = OkxSubscriptionTopic{
-			Channel: "tickers",
+		okxTopics[i] = OkxWsSubscriptionTopic{
+			Channel: "candle3m",
 			InstID:  cp.Join("-"),
 		}
 	}
 
-	subscriptionMsgs[0] = OkxSubscriptionMsg{
+	subscriptionMsgs[0] = OkxWsSubscriptionMsg{
 		Op:   "subscribe",
 		Args: okxTopics,
 	}
@@ -177,6 +167,49 @@ func (p *OkxProvider) SendSubscriptionMsgs(msgs []interface{}) error {
 
 // GetTickerPrices returns the tickerPrices based on the saved map.
 func (p *OkxProvider) GetTickerPrices(cps ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
+
+	go func(p *OkxProvider) {
+		requiredSymbols := make(map[string]bool, len(cps))
+
+		for _, cp := range cps {
+			requiredSymbols[cp.Join("-")] = true
+		}
+
+		client := &http.Client{}
+
+		req, err := http.NewRequest(
+			"GET", p.endpoints.Rest+"/api/v5/market/tickers", nil,
+		)
+		if err != nil {
+			p.logger.Err(err)
+		}
+
+		query := req.URL.Query()
+		query.Add("instType", "SWAP")
+		req.URL.RawQuery = query.Encode()
+
+		resp, err := client.Do(req)
+		if err != nil {
+			p.logger.Err(err)
+		}
+		defer resp.Body.Close()
+
+		var tickerResp OkxRestTickerResponse
+		err = json.NewDecoder(resp.Body).Decode(&tickerResp)
+		if err != nil {
+			return
+		}
+
+		for _, ticker := range tickerResp.Data {
+			if _, ok := requiredSymbols[ticker.InstID]; ok {
+				p.setTickerVolume(ticker.InstID, ticker.Volume)
+			}
+		}
+
+		p.logger.Info().Msg("Done updating volumes")
+
+	}(p)
+
 	return getTickerPrices(p, cps)
 }
 
@@ -185,87 +218,76 @@ func (p *OkxProvider) GetTickerPrice(cp types.CurrencyPair) (types.TickerPrice, 
 	defer p.mtx.RUnlock()
 
 	instrumentID := cp.Join("-")
-	tickerPair, ok := p.tickers[instrumentID]
+	ticker, ok := p.tickers[instrumentID]
 	if !ok {
 		return types.TickerPrice{}, fmt.Errorf("okx failed to get ticker price for %s", instrumentID)
 	}
 
-	return tickerPair.toTickerPrice()
+	timestamp, err := strconv.ParseInt(ticker.Time, 0, 64)
+	if err != nil {
+		return types.TickerPrice{}, fmt.Errorf("okx failed to convert timestamp for %s", instrumentID)
+	}
+
+	return types.TickerPrice{
+		Price:  sdk.MustNewDecFromStr(ticker.Price),
+		Volume: sdk.MustNewDecFromStr(ticker.Volume),
+		Time:   timestamp,
+	}, nil
 }
 
 func (p *OkxProvider) messageReceived(messageType int, bz []byte) {
 	var (
-		tickerResp OkxTickerResponse
-		tickerErr  error
+		candleMsg OkxWsCandleMsg
 	)
 
 	// sometimes the message received is not a ticker or a candle response.
-	tickerErr = json.Unmarshal(bz, &tickerResp)
-	if tickerResp.ID.Channel == "tickers" {
-		for _, tickerPair := range tickerResp.Data {
-			p.setTickerPair(tickerPair)
-			telemetryWebsocketMessage(ProviderOkx, MessageTypeTicker)
-		}
+	err := json.Unmarshal(bz, &candleMsg)
+	if err == nil && len(candleMsg.Data) > 0 {
+		p.setTicker(candleMsg)
+		telemetryWebsocketMessage(ProviderOkx, MessageTypeTicker)
 		return
 	}
 
 	p.logger.Error().
 		Int("length", len(bz)).
-		AnErr("ticker", tickerErr).
+		AnErr("ticker", err).
 		Str("msg", string(bz)).
 		Msg("Error on receive message")
 }
 
-func (p *OkxProvider) setTickerPair(tickerPair OkxTickerPair) {
+func (p *OkxProvider) setTicker(candleMsg OkxWsCandleMsg) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
-	p.tickers[tickerPair.InstID] = tickerPair
+
+	symbol := candleMsg.Args.InstID
+	price := candleMsg.Data[0][4]
+	timestamp := candleMsg.Data[0][0]
+
+	if ticker, ok := p.tickers[symbol]; ok {
+		ticker.Price = price
+		ticker.Time = timestamp
+		p.tickers[symbol] = ticker
+	} else {
+		p.tickers[symbol] = OkxTicker{
+			Price:  price,
+			Volume: "0",
+			Time:   timestamp,
+		}
+	}
+}
+
+func (p *OkxProvider) setTickerVolume(symbol string, volume string) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	if ticker, ok := p.tickers[symbol]; ok {
+		ticker.Volume = volume
+		p.tickers[symbol] = ticker
+	}
 }
 
 // GetAvailablePairs return all available pairs symbol to subscribe.
 func (p *OkxProvider) GetAvailablePairs() (map[string]struct{}, error) {
-	resp, err := http.Get(p.endpoints.Rest + okxRestPath)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var pairsSummary struct {
-		Data []OkxInstID `json:"data"`
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&pairsSummary); err != nil {
-		return nil, err
-	}
-
-	availablePairs := make(map[string]struct{}, len(pairsSummary.Data))
-	for _, pair := range pairsSummary.Data {
-		splitInstID := strings.Split(pair.InstID, "-")
-		if len(splitInstID) != 2 {
-			continue
-		}
-
-		cp := types.CurrencyPair{
-			Base:  strings.ToUpper(splitInstID[0]),
-			Quote: strings.ToUpper(splitInstID[1]),
-		}
-		availablePairs[cp.String()] = struct{}{}
-	}
-
-	return availablePairs, nil
-}
-
-func (ticker OkxTickerPair) toTickerPrice() (types.TickerPrice, error) {
-	timestamp, err := strconv.Atoi(ticker.TS)
-	if err != nil {
-		return types.TickerPrice{}, err
-	}
-
-	return types.NewTickerPrice(
-		string(ProviderOkx),
-		ticker.InstID,
-		ticker.Last,
-		ticker.Vol24h,
-		int64(timestamp),
-	)
+	// not used yet, so skipping this unless needed
+	return make(map[string]struct{}, 0), nil
 }

--- a/oracle/provider/okx_test.go
+++ b/oracle/provider/okx_test.go
@@ -26,7 +26,6 @@ func TestOkxProvider_GetTickerPrices(t *testing.T) {
 		tickers["ATOM-USDT"] = OkxTicker{
 			Price:  testAtomPriceString,
 			Volume: testAtomVolumeString,
-			Time:   "0",
 		}
 
 		p.tickers = tickers
@@ -51,13 +50,11 @@ func TestOkxProvider_GetTickerPrices(t *testing.T) {
 		tickers["ATOM-USDT"] = OkxTicker{
 			Price:  testAtomPriceString,
 			Volume: testAtomVolumeString,
-			Time:   "0",
 		}
 
 		tickers["BTC-USDT"] = OkxTicker{
 			Price:  testBtcPriceString,
 			Volume: testBtcVolumeString,
-			Time:   "0",
 		}
 
 		p.tickers = tickers

--- a/oracle/provider/phemex.go
+++ b/oracle/provider/phemex.go
@@ -224,7 +224,7 @@ func (p *PhemexProvider) GetTickerPrice(cp types.CurrencyPair) (types.TickerPric
 	return types.TickerPrice{
 		Price:  sdk.NewDec(ticker.Price).QuoInt64(1e8),
 		Volume: sdk.NewDec(ticker.Volume).QuoInt64(1e8),
-		Time:   ticker.Time / 1000,
+		Time:   ticker.Time,
 	}, nil
 }
 

--- a/oracle/provider/phemex.go
+++ b/oracle/provider/phemex.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"net/url"
 	"price-feeder/oracle/types"
-	"strings"
 	"sync"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/gorilla/websocket"
@@ -17,7 +19,7 @@ import (
 const (
 	phemexWSHost   = "phemex.com"
 	phemexWSPath   = "/ws"
-	phemexRestHost = "api.phemex.com"
+	phemexRestHost = "https://api.phemex.com"
 )
 
 var _ Provider = (*PhemexProvider)(nil)
@@ -28,11 +30,17 @@ type (
 		logger          zerolog.Logger
 		mtx             sync.Mutex
 		endpoints       Endpoint
-		tickers         map[string]PhemexTickerMsg
+		tickers         map[string]PhemexTicker
 		subscribedPairs map[string]types.CurrencyPair
 	}
 
-	PhemexSubscriptionMsg struct {
+	PhemexTicker struct {
+		Price  int64
+		Volume int64
+		Time   int64
+	}
+
+	PhemexWsSubscriptionMsg struct {
 		ID     uint     `json:"id"`
 		Method string   `json:"method"`
 		Params []string `json:"params"`
@@ -48,15 +56,20 @@ type (
 		Message string `json:"message"`
 	}
 
-	PhemexTickerMsg struct {
-		Data      PhemexTicker `json:"spot_market24h"`
-		Timestamp uint64       `json:"timestamp"`
+	PhemexWsTradeMsg struct {
+		Type   string               `json:"type"`
+		Symbol string               `json:"symbol"`
+		Trades [][4]json.RawMessage `json:"trades"`
 	}
 
-	PhemexTicker struct {
-		Symbol string `json:"symbol"`
-		Price  uint64 `json:"lastEp"`
-		Volume uint64 `json:"volumeEv"`
+	PhemexRestTickerResponse struct {
+		Result PhemexRestTicker `json:"result"`
+	}
+
+	PhemexRestTicker struct {
+		Price  int64 `json:"lastEp"`
+		Volume int64 `json:"volumeEv"`
+		Time   int64 `json:"timestamp"`
 	}
 )
 
@@ -85,7 +98,7 @@ func NewPhemexProvider(
 	provider := &PhemexProvider{
 		logger:          phemexLogger,
 		endpoints:       endpoints,
-		tickers:         map[string]PhemexTickerMsg{},
+		tickers:         map[string]PhemexTicker{},
 		subscribedPairs: map[string]types.CurrencyPair{},
 	}
 
@@ -110,12 +123,14 @@ func NewPhemexProvider(
 }
 
 func (p *PhemexProvider) GetSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {
-	subscriptionMsgs := make([]interface{}, 1)
+	subscriptionMsgs := make([]interface{}, len(cps))
 
-	subscriptionMsgs[0] = PhemexSubscriptionMsg{
-		ID:     1,
-		Method: "spot_market24h.subscribe",
-		Params: []string{},
+	for i, cp := range cps {
+		subscriptionMsgs[i] = PhemexWsSubscriptionMsg{
+			ID:     1,
+			Method: "trade.subscribe",
+			Params: []string{"s" + cp.String()},
+		}
 	}
 
 	return subscriptionMsgs
@@ -144,7 +159,54 @@ func (p *PhemexProvider) SendSubscriptionMsgs(msgs []interface{}) error {
 	return p.wsc.AddSubscriptionMsgs(msgs)
 }
 
+// GetTickerPrices converts and returns all internally stored tickers and
+// updates the volume data of all tickers. The volume data is retrieved via
+// the REST endpoint which is takes some time. Therefore the update is run in
+// parallel and the update takes effect after the current values are returned
 func (p *PhemexProvider) GetTickerPrices(cps ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
+	go func(p *PhemexProvider) {
+		for _, cp := range cps {
+			client := &http.Client{}
+
+			req, err := http.NewRequest(
+				"GET", p.endpoints.Rest+"/md/spot/ticker/24hr", nil,
+			)
+			if err != nil {
+				p.logger.Err(err)
+				continue
+			}
+
+			query := req.URL.Query()
+			query.Add("symbol", "s"+cp.String())
+			req.URL.RawQuery = query.Encode()
+
+			resp, err := client.Do(req)
+			if err != nil {
+				p.logger.Err(err)
+				continue
+			}
+			defer resp.Body.Close()
+
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				p.logger.Err(err)
+				continue
+			}
+
+			var tickerResponse PhemexRestTickerResponse
+
+			err = json.Unmarshal(body, &tickerResponse)
+			if err != nil {
+				p.logger.Err(err)
+				continue
+			}
+
+			p.setTickerVolume("s"+cp.String(), tickerResponse.Result.Volume)
+		}
+
+		p.logger.Info().Msg("Done updating volumes")
+	}(p)
+
 	return getTickerPrices(p, cps)
 }
 
@@ -159,44 +221,24 @@ func (p *PhemexProvider) GetTickerPrice(cp types.CurrencyPair) (types.TickerPric
 		return types.TickerPrice{}, fmt.Errorf("phemex failed to get ticker price for %s", key)
 	}
 
-	price, err := sdk.NewDecFromStr(fmt.Sprintf("%d", ticker.Data.Price))
-	if err != nil {
-		return types.TickerPrice{}, fmt.Errorf("phemex failed to convert ticker price for %s", key)
-	}
-
-	price = price.QuoInt64(100000000)
-
-	volume, err := sdk.NewDecFromStr(fmt.Sprintf("%d", ticker.Data.Volume))
-	if err != nil {
-		return types.TickerPrice{}, fmt.Errorf("phemex failed to convert ticker price for %s", key)
-	}
-
-	volume = volume.QuoInt64(100000000)
-
-	return types.NewTickerPrice(
-		string(ProviderPhemex),
-		cp.String(),
-		price.String(),
-		volume.String(),
-		int64(ticker.Timestamp/1000),
-	)
+	return types.TickerPrice{
+		Price:  sdk.NewDec(ticker.Price).QuoInt64(1e8),
+		Volume: sdk.NewDec(ticker.Volume).QuoInt64(1e8),
+		Time:   ticker.Time / 1000,
+	}, nil
 }
 
 func (p *PhemexProvider) messageReceived(messageType int, bz []byte) {
 	var (
-		tickerMsg  PhemexTickerMsg
+		tradeMsg   PhemexWsTradeMsg
 		genericMsg PhemexGenericMsg
-		tickerErr  error
+		tradeErr   error
 	)
 
-	tickerErr = json.Unmarshal(bz, &tickerMsg)
-	// symbol for spot ticker has a prefix "s", e.x.: "sBTCUSDT"
-	if tickerErr == nil && strings.HasPrefix(tickerMsg.Data.Symbol, "s") {
-		if _, ok := p.subscribedPairs[tickerMsg.Data.Symbol[1:]]; ok {
-			p.setTickerPair(tickerMsg)
-			telemetryWebsocketMessage(ProviderPhemex, MessageTypeTicker)
-
-		}
+	tradeErr = json.Unmarshal(bz, &tradeMsg)
+	if tradeErr == nil && len(tradeMsg.Trades) > 0 && tradeMsg.Type == "incremental" {
+		p.setTickerPrice(tradeMsg)
+		telemetryWebsocketMessage(ProviderPhemex, MessageTypeTrade)
 		return
 	}
 
@@ -207,16 +249,46 @@ func (p *PhemexProvider) messageReceived(messageType int, bz []byte) {
 
 	p.logger.Error().
 		Int("length", len(bz)).
-		AnErr("ticker", tickerErr).
+		AnErr("trade", tradeErr).
 		Str("msg", string(bz)).
 		Msg("Error on receive message")
 }
 
-func (p *PhemexProvider) setTickerPair(ticker PhemexTickerMsg) {
+func (p *PhemexProvider) setTickerVolume(symbol string, volume int64) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 
-	p.tickers[ticker.Data.Symbol] = ticker
+	if ticker, ok := p.tickers[symbol]; ok {
+		ticker.Volume = volume
+		p.tickers[symbol] = ticker
+	}
+}
+
+// setTickerPrice updates the price and time value of the ticker provided.
+// Sets it with volume = 0, if not present in internal tickers map
+func (p *PhemexProvider) setTickerPrice(tradeMsg PhemexWsTradeMsg) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	var price int64
+	err := json.Unmarshal(tradeMsg.Trades[len(tradeMsg.Trades)-1][2], &price)
+	if err != nil {
+		return
+	}
+
+	time := time.Now().UnixMilli()
+
+	if ticker, ok := p.tickers[tradeMsg.Symbol]; ok {
+		ticker.Price = price
+		ticker.Time = time
+		p.tickers[tradeMsg.Symbol] = ticker
+	} else {
+		p.tickers[tradeMsg.Symbol] = PhemexTicker{
+			Price:  price,
+			Volume: 0,
+			Time:   time,
+		}
+	}
 }
 
 func (p *PhemexProvider) GetAvailablePairs() (map[string]struct{}, error) {

--- a/oracle/provider/phemex_test.go
+++ b/oracle/provider/phemex_test.go
@@ -3,11 +3,9 @@ package provider
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"price-feeder/oracle/types"
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
@@ -22,12 +20,10 @@ func TestPhemexProvider_GetTickerPrices(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("valid_request_single_ticker", func(t *testing.T) {
-		tickers := map[string]PhemexTickerMsg{}
-		tickers["sATOMUSDT"] = PhemexTickerMsg{
-			Data: PhemexTicker{
-				Price:  testAtomPriceInt64,
-				Volume: testAtomVolumeInt64,
-			},
+		tickers := map[string]PhemexTicker{}
+		tickers["sATOMUSDT"] = PhemexTicker{
+			Price:  testAtomPriceInt64,
+			Volume: testAtomVolumeInt64,
 		}
 
 		p.tickers = tickers
@@ -38,29 +34,25 @@ func TestPhemexProvider_GetTickerPrices(t *testing.T) {
 		require.Len(t, prices, 1)
 		require.Equal(
 			t,
-			sdk.MustNewDecFromStr(fmt.Sprintf("%d", testAtomPriceInt64)).QuoInt64(100000000),
+			testAtomPriceDec,
 			prices["ATOMUSDT"].Price,
 		)
 		require.Equal(
 			t,
-			sdk.MustNewDecFromStr(fmt.Sprintf("%d", testAtomVolumeInt64)).QuoInt64(100000000),
+			testAtomVolumeDec,
 			prices["ATOMUSDT"].Volume,
 		)
 	})
 
 	t.Run("valid_request_multi_ticker", func(t *testing.T) {
-		tickers := map[string]PhemexTickerMsg{}
-		tickers["sATOMUSDT"] = PhemexTickerMsg{
-			Data: PhemexTicker{
-				Price:  testAtomPriceInt64,
-				Volume: testAtomVolumeInt64,
-			},
+		tickers := map[string]PhemexTicker{}
+		tickers["sATOMUSDT"] = PhemexTicker{
+			Price:  testAtomPriceInt64,
+			Volume: testAtomVolumeInt64,
 		}
-		tickers["sBTCUSDT"] = PhemexTickerMsg{
-			Data: PhemexTicker{
-				Price:  testBtcPriceInt64,
-				Volume: testBtcVolumeInt64,
-			},
+		tickers["sBTCUSDT"] = PhemexTicker{
+			Price:  testBtcPriceInt64,
+			Volume: testBtcVolumeInt64,
 		}
 
 		p.tickers = tickers
@@ -74,22 +66,22 @@ func TestPhemexProvider_GetTickerPrices(t *testing.T) {
 		require.Len(t, prices, 2)
 		require.Equal(
 			t,
-			sdk.MustNewDecFromStr(fmt.Sprintf("%d", testBtcPriceInt64)).QuoInt64(100000000),
+			testBtcPriceDec,
 			prices["BTCUSDT"].Price,
 		)
 		require.Equal(
 			t,
-			sdk.MustNewDecFromStr(fmt.Sprintf("%d", testBtcVolumeInt64)).QuoInt64(100000000),
+			testBtcVolumeDec,
 			prices["BTCUSDT"].Volume,
 		)
 		require.Equal(
 			t,
-			sdk.MustNewDecFromStr(fmt.Sprintf("%d", testAtomPriceInt64)).QuoInt64(100000000),
+			testAtomPriceDec,
 			prices["ATOMUSDT"].Price,
 		)
 		require.Equal(
 			t,
-			sdk.MustNewDecFromStr(fmt.Sprintf("%d", testAtomVolumeInt64)).QuoInt64(100000000),
+			testAtomVolumeDec,
 			prices["ATOMUSDT"].Volume,
 		)
 	})

--- a/oracle/provider/provider.go
+++ b/oracle/provider/provider.go
@@ -38,6 +38,7 @@ const (
 	ProviderMexc      Name = "mexc"
 	ProviderCrypto    Name = "crypto"
 	ProviderMock      Name = "mock"
+	ProviderStride    Name = "stride"
 )
 
 var (

--- a/oracle/provider/provider.go
+++ b/oracle/provider/provider.go
@@ -51,10 +51,12 @@ var (
 
 	testAtomPriceFloat64  = float64(12.3456)
 	testAtomPriceString   = "12.3456"
-	testAtomPriceInt64    = uint64(1234560000)
+	testAtomPriceInt64    = int64(1234560000)
+	testAtomPriceDec      = sdk.NewDec(1234560000).QuoInt64(100000000)
 	testAtomVolumeFloat64 = float64(7654321.98765)
 	testAtomVolumeString  = "7654321.98765"
-	testAtomVolumeInt64   = uint64(765432198765000)
+	testAtomVolumeInt64   = int64(765432198765000)
+	testAtomVolumeDec     = sdk.NewDec(765432198765000).QuoInt64(100000000)
 
 	testBtcUsdtCurrencyPair = types.CurrencyPair{
 		Base:  "BTC",
@@ -63,10 +65,12 @@ var (
 
 	testBtcPriceFloat64  = float64(12345.6789)
 	testBtcPriceString   = "12345.6789"
-	testBtcPriceInt64    = uint64(1234567890000)
+	testBtcPriceInt64    = int64(1234567890000)
+	testBtcPriceDec      = sdk.NewDec(1234567890000).QuoInt64(100000000)
 	testBtcVolumeFloat64 = float64(7654.32198765)
 	testBtcVolumeString  = "7654.32198765"
-	testBtcVolumeInt64   = uint64(765432198765)
+	testBtcVolumeInt64   = int64(765432198765)
+	testBtcVolumeDec     = sdk.NewDec(765432198765).QuoInt64(100000000)
 )
 
 type (

--- a/oracle/provider/stride.go
+++ b/oracle/provider/stride.go
@@ -51,8 +51,6 @@ func (p *StrideProvider) GetTickerPrice(cp types.CurrencyPair) (types.TickerPric
 }
 
 func (p *StrideProvider) GetTickerPrices(cps ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
-	fmt.Println(cps)
-
 	resp, err := http.Get(p.baseURL + "/api/Stride-Labs/stride/stakeibc/host_zone")
 	if err != nil {
 		return nil, err
@@ -88,8 +86,6 @@ func (p *StrideProvider) GetTickerPrices(cps ...types.CurrencyPair) (map[string]
 			}
 		}
 	}
-
-	fmt.Println(tickerPrices)
 
 	return tickerPrices, nil
 }

--- a/oracle/provider/stride.go
+++ b/oracle/provider/stride.go
@@ -1,0 +1,120 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"price-feeder/oracle/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+const (
+	strideRestURL = "https://stride-fleet.main.stridenet.co/"
+)
+
+var _ Provider = (*StrideProvider)(nil)
+
+type (
+	StrideProvider struct {
+		baseURL string
+	}
+
+	StrideRestHostZoneResponse struct {
+		HostZones []StrideHostZone `json:"host_zone"`
+	}
+
+	StrideHostZone struct {
+		ChainID        string `json:"chain_id"`
+		HostDenom      string `json:"host_denom"`
+		RedemptionRate string `json:"redemption_rate"`
+	}
+)
+
+func NewStrideProvider(endpoint Endpoint) *StrideProvider {
+	if endpoint.Name == ProviderStride {
+		return &StrideProvider{
+			baseURL: endpoint.Rest,
+		}
+	}
+	return &StrideProvider{
+		baseURL: strideRestURL,
+	}
+}
+
+func (p *StrideProvider) GetTickerPrice(cp types.CurrencyPair) (types.TickerPrice, error) {
+	return types.TickerPrice{}, nil
+}
+
+func (p *StrideProvider) GetTickerPrices(cps ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
+	fmt.Println(cps)
+
+	resp, err := http.Get(p.baseURL + "/api/Stride-Labs/stride/stakeibc/host_zone")
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	bz, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read host zone response body: %w", err)
+	}
+
+	var hostZoneResp StrideRestHostZoneResponse
+	err = json.Unmarshal(bz, &hostZoneResp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal host zone response body: %w", err)
+	}
+
+	hostDenoms := make(map[string]string)
+	for _, cp := range cps {
+		hostDenoms["u"+strings.ToLower(cp.Quote)] = cp.String()
+	}
+
+	timestamp := time.Now().UnixMilli()
+	tickerPrices := make(map[string]types.TickerPrice)
+
+	for _, hostZone := range hostZoneResp.HostZones {
+		if symbol, ok := hostDenoms[hostZone.HostDenom]; ok {
+			tickerPrices[symbol] = types.TickerPrice{
+				Price:  sdk.MustNewDecFromStr(hostZone.RedemptionRate),
+				Volume: sdk.NewDec(1),
+				Time:   timestamp,
+			}
+		}
+	}
+
+	fmt.Println(tickerPrices)
+
+	return tickerPrices, nil
+}
+
+// SubscribeCurrencyPairs performs a no-op since fin does not use websockets
+func (p *StrideProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
+	return nil
+}
+
+func (p *StrideProvider) GetSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {
+	return nil
+}
+
+func (p *StrideProvider) GetSubscribedPair(s string) (types.CurrencyPair, bool) {
+	return types.CurrencyPair{}, true
+}
+
+func (p *StrideProvider) SendSubscriptionMsgs(msgs []interface{}) error {
+	return nil
+}
+
+func (p *StrideProvider) SetSubscribedPair(cp types.CurrencyPair) {}
+
+// GetAvailablePairs return all available pairs symbol to susbscribe.
+func (p *StrideProvider) GetAvailablePairs() (map[string]struct{}, error) {
+	// not used yet, so skipping this unless needed
+	return make(map[string]struct{}, 0), nil
+}


### PR DESCRIPTION
- Use ticker_batch channel for Coinbase
- Use trade or candle channels for prices and REST API for 24h volumes for Huobi, MEXC and OKX
- Fix ticker times in Phemex provider
- Only show messages about deviating or stale prices on debug level
- Add POC for Stride redemption rates