### PR TITLE
Stabilize reported prices

### DIFF
--- a/cmd/price-feeder.go
+++ b/cmd/price-feeder.go
@@ -92,12 +92,16 @@ func priceFeederCmdHandler(cmd *cobra.Command, args []string) error {
 		logWriter = os.Stderr
 
 	case logLevelText:
-		logWriter = zerolog.ConsoleWriter{Out: os.Stderr}
+		logWriter = zerolog.ConsoleWriter{
+			Out:        os.Stderr,
+			TimeFormat: time.StampMilli,
+		}
 
 	default:
 		return fmt.Errorf("invalid logging format: %s", logFormatStr)
 	}
 
+	zerolog.TimeFieldFormat = time.StampMilli
 	logger := zerolog.New(logWriter).Level(logLvl).With().Timestamp().Logger()
 
 	cfg, err := config.ParseConfig(args[0])

--- a/oracle/provider/binance.go
+++ b/oracle/provider/binance.go
@@ -11,6 +11,7 @@ import (
 
 	"price-feeder/oracle/types"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
 )
@@ -41,35 +42,39 @@ type (
 		subscribedPairs map[string]types.CurrencyPair // Symbol => types.CurrencyPair
 	}
 
-	// BinanceTicker ticker price response. https://pkg.go.dev/encoding/json#Unmarshal
-	// Unmarshal matches incoming object keys to the keys used by Marshal (either the
-	// struct field name or its tag), preferring an exact match but also accepting a
-	// case-insensitive match. C field which is Statistics close time is not used, but
-	// it avoids to implement specific UnmarshalJSON.
-	BinanceTicker struct {
-		Symbol    string `json:"s"` // Symbol ex.: BTCUSDT
-		LastPrice string `json:"c"` // Last price ex.: 0.0025
-		Volume    string `json:"v"` // Total traded base asset volume ex.: 1000
-		Time      uint64 `json:"C"` // Statistics close time
-	}
-
 	// BinanceSubscribeMsg Msg to subscribe all the tickers channels.
-	BinanceSubscriptionMsg struct {
+	BinanceWsSubscriptionMsg struct {
 		Method string   `json:"method"` // SUBSCRIBE/UNSUBSCRIBE
 		Params []string `json:"params"` // streams to subscribe ex.: usdtatom@ticker
 		ID     uint16   `json:"id"`     // identify messages going back and forth
 	}
 
-	// BinanceSubscriptionResp the response structure for a binance subscription response
-	BinanceSubscriptionResp struct {
+	// BinanceWsSubscriptionResponse the response structure for a binance subscription response
+	BinanceWsSubscriptionResponse struct {
 		Result string `json:"result"`
 		ID     uint16 `json:"id"`
 	}
 
-	// BinancePairSummary defines the response structure for a Binance pair
-	// summary.
-	BinancePairSummary struct {
+	BinanceWsCandleMsg struct {
+		EventType string          `json:"e"`
+		Symbol    string          `json:"s"`
+		Time      int64           `json:"E"`
+		Candle    BinanceWsCandle `json:"k"`
+	}
+
+	BinanceWsCandle struct {
+		Close string `json:"c"`
+	}
+
+	BinanceRest24hTicker struct {
 		Symbol string `json:"symbol"`
+		Volume string `json:"volume"`
+	}
+
+	BinanceTicker struct {
+		Price  string
+		Volume string
+		Time   int64
 	}
 )
 
@@ -129,13 +134,13 @@ func NewBinanceProvider(
 }
 
 func (p *BinanceProvider) GetSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {
-	msg := BinanceSubscriptionMsg{
+	msg := BinanceWsSubscriptionMsg{
 		Method: "SUBSCRIBE",
 		Params: make([]string, len(cps)),
 		ID:     1,
 	}
 	for i, cp := range cps {
-		msg.Params[i] = strings.ToLower(cp.String()) + "@ticker"
+		msg.Params[i] = strings.ToLower(cp.String()) + "@kline_1m"
 	}
 	return []interface{}{msg}
 }
@@ -165,6 +170,35 @@ func (p *BinanceProvider) SendSubscriptionMsgs(msgs []interface{}) error {
 
 // GetTickerPrices returns the tickerPrices based on the provided pairs.
 func (p *BinanceProvider) GetTickerPrices(cps ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
+	go func(p *BinanceProvider) {
+		requiredSymbols := make(map[string]bool, len(cps))
+
+		for _, cp := range cps {
+			requiredSymbols[cp.String()] = true
+		}
+
+		resp, err := http.Get(p.endpoints.Rest + "/api/v3/ticker/24hr")
+		if err != nil {
+			return
+		}
+		defer resp.Body.Close()
+
+		var tickerResp []BinanceRest24hTicker
+		err = json.NewDecoder(resp.Body).Decode(&tickerResp)
+		if err != nil {
+			return
+		}
+
+		for _, ticker := range tickerResp {
+			if _, ok := requiredSymbols[ticker.Symbol]; ok {
+				p.setTickerVolume(ticker.Symbol, ticker.Volume)
+			}
+		}
+
+		p.logger.Info().Msg("Done updating volumes")
+
+	}(p)
+
 	return getTickerPrices(p, cps)
 }
 
@@ -179,21 +213,34 @@ func (p *BinanceProvider) GetTickerPrice(cp types.CurrencyPair) (types.TickerPri
 		return types.TickerPrice{}, fmt.Errorf("binance failed to get ticker price for %s", key)
 	}
 
-	return ticker.toTickerPrice()
+	return types.TickerPrice{
+		Price:  sdk.MustNewDecFromStr(ticker.Price),
+		Volume: sdk.MustNewDecFromStr(ticker.Volume),
+		Time:   ticker.Time * 1000,
+	}, nil
 }
 
 func (p *BinanceProvider) messageReceived(messageType int, bz []byte) {
 	var (
-		tickerResp       BinanceTicker
-		tickerErr        error
-		subscribeResp    BinanceSubscriptionResp
+		// tickerResp       BinanceTicker
+		// tickerErr        error
+		candleMsg        BinanceWsCandleMsg
+		candleErr        error
+		subscribeResp    BinanceWsSubscriptionResponse
 		subscribeRespErr error
 	)
 
-	tickerErr = json.Unmarshal(bz, &tickerResp)
-	if tickerErr == nil {
-		p.setTickerPair(tickerResp)
-		telemetryWebsocketMessage(ProviderBinance, MessageTypeTicker)
+	// tickerErr = json.Unmarshal(bz, &tickerResp)
+	// if tickerErr == nil {
+	// 	p.setTickerPair(tickerResp)
+	// 	telemetryWebsocketMessage(ProviderBinance, MessageTypeTicker)
+	// 	return
+	// }
+
+	candleErr = json.Unmarshal(bz, &candleMsg)
+	if candleErr == nil {
+		p.setTickerPrice(candleMsg)
+		telemetryWebsocketMessage(ProviderBinance, MessageTypeCandle)
 		return
 	}
 
@@ -204,50 +251,64 @@ func (p *BinanceProvider) messageReceived(messageType int, bz []byte) {
 
 	p.logger.Error().
 		Int("length", len(bz)).
-		AnErr("ticker", tickerErr).
+		AnErr("candle", candleErr).
 		AnErr("subscribeResp", subscribeRespErr).
 		Str("msg", string(bz)).
 		Msg("Error on receive message")
 }
 
-func (p *BinanceProvider) setTickerPair(ticker BinanceTicker) {
+// func (p *BinanceProvider) setTickerPair(ticker BinanceTicker) {
+// 	p.mtx.Lock()
+// 	defer p.mtx.Unlock()
+// 	p.tickers[ticker.Symbol] = ticker
+// }
+
+func (p *BinanceProvider) setTickerPrice(candleMsg BinanceWsCandleMsg) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
-	p.tickers[ticker.Symbol] = ticker
+
+	symbol := candleMsg.Symbol
+
+	if ticker, ok := p.tickers[symbol]; ok {
+		ticker.Price = candleMsg.Candle.Close
+		ticker.Time = candleMsg.Time
+		p.tickers[symbol] = ticker
+	} else {
+		p.tickers[symbol] = BinanceTicker{
+			Price:  candleMsg.Candle.Close,
+			Volume: "0",
+			Time:   candleMsg.Time,
+		}
+	}
+}
+
+func (p *BinanceProvider) setTickerVolume(symbol string, volume string) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	if ticker, ok := p.tickers[symbol]; ok {
+		ticker.Volume = volume
+		p.tickers[symbol] = ticker
+	}
 }
 
 // GetAvailablePairs returns all pairs to which the provider can subscribe.
 // ex.: map["ATOMUSDT" => {}, "UMEEUSDC" => {}].
 func (p *BinanceProvider) GetAvailablePairs() (map[string]struct{}, error) {
-	resp, err := http.Get(p.endpoints.Rest + binanceRestPath)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var pairsSummary []BinancePairSummary
-	if err := json.NewDecoder(resp.Body).Decode(&pairsSummary); err != nil {
-		return nil, err
-	}
-
-	availablePairs := make(map[string]struct{}, len(pairsSummary))
-	for _, pairName := range pairsSummary {
-		availablePairs[strings.ToUpper(pairName.Symbol)] = struct{}{}
-	}
-
-	return availablePairs, nil
+	// not used yet, so skipping this unless needed
+	return make(map[string]struct{}, 0), nil
 }
 
-func (ticker BinanceTicker) toTickerPrice() (types.TickerPrice, error) {
-	tickerPrice, err := types.NewTickerPrice(
-		string(ProviderBinance),
-		ticker.Symbol,
-		ticker.LastPrice,
-		ticker.Volume,
-		int64(ticker.Time),
-	)
-	if err != nil {
-		return types.TickerPrice{}, err
-	}
-	return tickerPrice, nil
-}
+// func (ticker BinanceTicker) toTickerPrice() (types.TickerPrice, error) {
+// 	tickerPrice, err := types.NewTickerPrice(
+// 		string(ProviderBinance),
+// 		ticker.Symbol,
+// 		ticker.LastPrice,
+// 		ticker.Volume,
+// 		int64(ticker.Time),
+// 	)
+// 	if err != nil {
+// 		return types.TickerPrice{}, err
+// 	}
+// 	return tickerPrice, nil
+// }

--- a/oracle/provider/bitget_test.go
+++ b/oracle/provider/bitget_test.go
@@ -16,85 +16,77 @@ func TestBitgetProvider_GetTickerPrices(t *testing.T) {
 		context.TODO(),
 		zerolog.Nop(),
 		Endpoint{},
-		types.CurrencyPair{Base: "BTC", Quote: "USDT"},
+		testBtcUsdtCurrencyPair,
 	)
 	require.NoError(t, err)
 
 	t.Run("valid_request_single_ticker", func(t *testing.T) {
-		lastPrice := "34.69000000"
-		volume := "2396974.02000000"
-		instId := "ATOMUSDT"
-
-		tickerMap := map[string]BitgetTicker{}
-		tickerMap[instId] = BitgetTicker{
-			Arg: BitgetSubscriptionArg{
-				Channel: "tickers",
-				InstID:  instId,
-			},
-			Data: []BitgetTickerData{
-				{
-					InstID: instId,
-					Price:  lastPrice,
-					Volume: volume,
-				},
-			},
+		tickers := map[string]BitgetTicker{}
+		tickers["ATOMUSDT"] = BitgetTicker{
+			Price:  testAtomPriceString,
+			Volume: testAtomVolumeString,
+			Time:   "0",
 		}
 
-		p.tickers = tickerMap
+		p.tickers = tickers
 
-		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+		prices, err := p.GetTickerPrices(testAtomUsdtCurrencyPair)
 		require.NoError(t, err)
 		require.Len(t, prices, 1)
-		require.Equal(t, sdk.MustNewDecFromStr(lastPrice), prices["ATOMUSDT"].Price)
-		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["ATOMUSDT"].Volume)
+		require.Equal(
+			t,
+			sdk.MustNewDecFromStr(testAtomPriceString),
+			prices["ATOMUSDT"].Price,
+		)
+		require.Equal(
+			t,
+			sdk.MustNewDecFromStr(testAtomVolumeString),
+			prices["ATOMUSDT"].Volume,
+		)
 	})
 
 	t.Run("valid_request_multi_ticker", func(t *testing.T) {
-		atomInstID := "ATOMUSDT"
-		atomLastPrice := "34.69000000"
-		lunaInstID := "LUNAUSDT"
-		lunaLastPrice := "41.35000000"
-		volume := "2396974.02000000"
+		tickers := map[string]BitgetTicker{}
+		tickers["ATOMUSDT"] = BitgetTicker{
+			Price:  testAtomPriceString,
+			Volume: testAtomVolumeString,
+			Time:   "0",
+		}
 
-		tickerMap := map[string]BitgetTicker{}
-		tickerMap[atomInstID] = BitgetTicker{
-			Arg: BitgetSubscriptionArg{
-				Channel: "tickers",
-				InstID:  atomInstID,
-			},
-			Data: []BitgetTickerData{
-				{
-					InstID: atomInstID,
-					Price:  atomLastPrice,
-					Volume: volume,
-				},
-			},
+		tickers["BTCUSDT"] = BitgetTicker{
+			Price:  testBtcPriceString,
+			Volume: testBtcVolumeString,
+			Time:   "0",
 		}
-		tickerMap[lunaInstID] = BitgetTicker{
-			Arg: BitgetSubscriptionArg{
-				Channel: "tickers",
-				InstID:  lunaInstID,
-			},
-			Data: []BitgetTickerData{
-				{
-					InstID: lunaInstID,
-					Price:  lunaLastPrice,
-					Volume: volume,
-				},
-			},
-		}
-		p.tickers = tickerMap
+
+		p.tickers = tickers
 		prices, err := p.GetTickerPrices(
-			types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
-			types.CurrencyPair{Base: "LUNA", Quote: "USDT"},
+			testAtomUsdtCurrencyPair,
+			testBtcUsdtCurrencyPair,
 		)
 
 		require.NoError(t, err)
 		require.Len(t, prices, 2)
-		require.Equal(t, sdk.MustNewDecFromStr(atomLastPrice), prices["ATOMUSDT"].Price)
-		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["ATOMUSDT"].Volume)
-		require.Equal(t, sdk.MustNewDecFromStr(lunaLastPrice), prices["LUNAUSDT"].Price)
-		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["LUNAUSDT"].Volume)
+		require.Equal(
+			t,
+			sdk.MustNewDecFromStr(testBtcPriceString),
+			prices["BTCUSDT"].Price,
+		)
+		require.Equal(
+			t,
+			sdk.MustNewDecFromStr(testBtcVolumeString),
+			prices["BTCUSDT"].Volume,
+		)
+		require.Equal(
+			t,
+			sdk.MustNewDecFromStr(testAtomPriceString),
+			prices["ATOMUSDT"].Price,
+		)
+		require.Equal(
+			t,
+			sdk.MustNewDecFromStr(testAtomVolumeString),
+			prices["ATOMUSDT"].Volume,
+		)
 	})
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {
@@ -102,19 +94,4 @@ func TestBitgetProvider_GetTickerPrices(t *testing.T) {
 		require.EqualError(t, err, "bitget failed to get ticker price for FOOBAR")
 		require.Nil(t, prices)
 	})
-}
-
-func TestBitgetProvider_AvailablePairs(t *testing.T) {
-	p, err := NewBitgetProvider(
-		context.TODO(),
-		zerolog.Nop(),
-		Endpoint{},
-		types.CurrencyPair{},
-	)
-	require.NoError(t, err)
-
-	pairs, err := p.GetAvailablePairs()
-	require.NoError(t, err)
-
-	require.NotEmpty(t, pairs)
 }

--- a/oracle/provider/coinbase.go
+++ b/oracle/provider/coinbase.go
@@ -185,7 +185,6 @@ func (p *CoinbaseProvider) GetTickerPrice(cp types.CurrencyPair) (types.TickerPr
 		return types.TickerPrice{}, fmt.Errorf("coinbase failed to get ticker price for %s", symbol)
 	}
 
-	fmt.Println(ticker)
 	return ticker, nil
 }
 

--- a/oracle/provider/coinbase.go
+++ b/oracle/provider/coinbase.go
@@ -4,30 +4,24 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
-	"net/url"
-	"strings"
 	"sync"
 	"time"
 
-	"github.com/gorilla/websocket"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
 
 	"price-feeder/oracle/types"
 )
 
 const (
-	coinbaseWSHost    = "ws-feed.exchange.coinbase.com"
-	coinbasePingCheck = time.Second * 28 // should be < 30
-	coinbaseRestHost  = "https://api.exchange.coinbase.com"
-	coinbaseRestPath  = "/products"
-	coinbaseTimeFmt   = "2006-01-02T15:04:05.000000Z"
-	unixMinute        = 60000
+	coinbaseRestHost   = "https://api.exchange.coinbase.com"
+	coinbaseTimeFormat = "2006-01-02T15:04:05.000000Z"
 )
 
 var (
-	_                  Provider = (*CoinbaseProvider)(nil)
-	CoinbaseTimeFormat          = "2006-01-02T15:04:05.000000Z"
+	_ Provider = (*CoinbaseProvider)(nil)
 )
 
 type (
@@ -36,52 +30,19 @@ type (
 	//
 	// REF: https://www.coinbase.io/docs/websocket/index.html
 	CoinbaseProvider struct {
-		wsc             *WebsocketController
+		rac             *GenericRequestController
 		logger          zerolog.Logger
-		reconnectTimer  *time.Ticker
 		mtx             sync.RWMutex
 		endpoints       Endpoint
-		tickers         map[string]CoinbaseWsTickerMsg // Symbol => CoinbaseWsTickerMsg
-		subscribedPairs map[string]types.CurrencyPair  // Symbol => types.CurrencyPair
+		client          *http.Client
+		tickers         map[string]types.TickerPrice  // Symbol => CoinbaseWsTickerMsg
+		subscribedPairs map[string]types.CurrencyPair // Symbol => types.CurrencyPair
 	}
 
-	// CoinbaseWsSubscriptionMsg Msg to subscribe to all channels.
-	CoinbaseWsSubscriptionMsg struct {
-		Type       string   `json:"type"`        // ex. "subscribe"
-		ProductIDs []string `json:"product_ids"` // streams to subscribe ex.: ["BOT-USDT", ...]
-		Channels   []string `json:"channels"`    // channels to subscribe to ex.: "ticker"
-	}
-
-	CoinbaseWsGenericMsg struct {
-		Type string `json:"type"`
-	}
-
-	// CoinbaseWsTickerMsg defines the ticker info we'd like to save.
-	CoinbaseWsTickerMsg struct {
-		Type      string `json:"type"`
-		ProductID string `json:"product_id"` // ex.: ATOM-USDT
-		Price     string `json:"price"`      // ex.: 523.0
-		Volume    string `json:"volume_24h"` // 24-hour volume
-		Time      string `json:"time"`       // timestamp
-	}
-
-	CoinbaseWsMatchMsg struct {
-		Type      string `json:"type"`
-		ProductID string `json:"product_id"`
-		Price     string `json:"price"`
-		Time      string `json:"time"`
-	}
-
-	// CoinbaseErrResponse defines the response body for errors.
-	CoinbaseErrResponse struct {
-		Type   string `json:"type"`   // should be "error"
-		Reason string `json:"reason"` // ex.: "tickers" is not a valid channel
-	}
-
-	// CoinbasePairSummary defines the response structure for a Coinbase pair summary.
-	CoinbasePairSummary struct {
-		Base  string `json:"base_currency"`
-		Quote string `json:"quote_currency"`
+	CoinbaseRestTickerResponse struct {
+		Price  string `json:"price"`
+		Volume string `json:"volume"`
+		Time   string `json:"time"`
 	}
 )
 
@@ -94,59 +55,37 @@ func NewCoinbaseProvider(
 ) (*CoinbaseProvider, error) {
 	if endpoints.Name != ProviderCoinbase {
 		endpoints = Endpoint{
-			Name:      ProviderCoinbase,
-			Rest:      coinbaseRestHost,
-			Websocket: coinbaseWSHost,
+			Name: ProviderCoinbase,
+			Rest: coinbaseRestHost,
 		}
-	}
-	wsURL := url.URL{
-		Scheme: "wss",
-		Host:   endpoints.Websocket,
 	}
 
 	coinbaseLogger := logger.With().Str("provider", string(ProviderCoinbase)).Logger()
 
 	provider := &CoinbaseProvider{
 		logger:          coinbaseLogger,
-		reconnectTimer:  time.NewTicker(coinbasePingCheck),
 		endpoints:       endpoints,
-		tickers:         map[string]CoinbaseWsTickerMsg{},
+		client:          newDefaultHTTPClient(),
+		tickers:         map[string]types.TickerPrice{},
 		subscribedPairs: map[string]types.CurrencyPair{},
 	}
 
-	setSubscribedPairs(provider, pairs...)
+	provider.SubscribeCurrencyPairs(pairs...)
 
-	provider.wsc = NewWebsocketController(
+	provider.rac = NewGenericRequestController(
 		ctx,
-		ProviderCoinbase,
-		wsURL,
-		provider.GetSubscriptionMsgs(pairs...),
-		provider.messageReceived,
-		defaultPingDuration,
-		websocket.PingMessage,
+		time.Second*5,
+		provider.requestPrices,
 		coinbaseLogger,
 	)
-	go provider.wsc.Start()
+
+	go provider.rac.Start()
 
 	return provider, nil
 }
 
 func (p *CoinbaseProvider) GetSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {
-	subscriptionMsgs := make([]interface{}, 1)
-
-	productIDs := make([]string, len(cps))
-
-	for i, cp := range cps {
-		productIDs[i] = cp.Join("-")
-	}
-
-	subscriptionMsgs[0] = CoinbaseWsSubscriptionMsg{
-		Type:       "subscribe",
-		ProductIDs: productIDs,
-		Channels:   []string{"ticker_batch", "matches"},
-	}
-
-	return subscriptionMsgs
+	return nil
 }
 
 func (p *CoinbaseProvider) GetSubscribedPair(s string) (types.CurrencyPair, bool) {
@@ -162,14 +101,73 @@ func (p *CoinbaseProvider) SetSubscribedPair(cp types.CurrencyPair) {
 }
 
 func (p *CoinbaseProvider) SubscribeCurrencyPairs(cps ...types.CurrencyPair) error {
+	// adjust request interval
+	interval := math.Ceil(float64(len(cps)) / 10 * 3)
+	p.logger.Debug().
+		Float64("interval", interval).
+		Msg("set request interval")
+
 	return subscribeCurrencyPairs(p, cps)
 }
 
 func (p *CoinbaseProvider) SendSubscriptionMsgs(msgs []interface{}) error {
+	return nil
+}
+
+func (p *CoinbaseProvider) requestPrices() error {
+	i := 0
+	for _, cp := range p.subscribedPairs {
+		go func(p *CoinbaseProvider, cp types.CurrencyPair) {
+			url := p.endpoints.Rest + "/products/" + cp.Join("-") + "/ticker"
+
+			p.logger.Debug().Msg("get " + url)
+
+			resp, err := p.client.Get(url)
+			if err != nil {
+				p.logger.Error().Msg("failed to get tickers")
+				return
+			}
+			defer resp.Body.Close()
+
+			var tickerResp CoinbaseRestTickerResponse
+			err = json.NewDecoder(resp.Body).Decode(&tickerResp)
+			if err != nil {
+				p.logger.Error().Msg("failed to parse rest response")
+				return
+			}
+
+			timestamp, err := time.Parse(coinbaseTimeFormat, tickerResp.Time)
+			if err != nil {
+				p.logger.Error().Msg("failed to parse timestamp")
+				return
+			}
+
+			ticker := types.TickerPrice{
+				Price:  sdk.MustNewDecFromStr(tickerResp.Price),
+				Volume: sdk.MustNewDecFromStr(tickerResp.Volume),
+				Time:   timestamp.UnixMilli(),
+			}
+
+			p.setTicker(cp.String(), ticker)
+		}(p, cp)
+
+		i = i + 1
+
+		if i == 10 {
+			p.logger.Debug().Msg("sleep for 1.2s")
+			i = 0
+			time.Sleep(time.Millisecond * 1200)
+		}
+	}
+
+	return nil
+}
+
+func (p *CoinbaseProvider) setTicker(symbol string, ticker types.TickerPrice) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 
-	return p.wsc.AddSubscriptionMsgs(msgs)
+	p.tickers[symbol] = ticker
 }
 
 // GetTickerPrices returns the tickerPrices based on the saved map.
@@ -181,108 +179,18 @@ func (p *CoinbaseProvider) GetTickerPrice(cp types.CurrencyPair) (types.TickerPr
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
-	gp := cp.Join("-")
-	if tickerPair, ok := p.tickers[gp]; ok {
-		return tickerPair.toTickerPrice()
+	symbol := cp.String()
+	ticker, ok := p.tickers[symbol]
+	if !ok {
+		return types.TickerPrice{}, fmt.Errorf("coinbase failed to get ticker price for %s", symbol)
 	}
 
-	return types.TickerPrice{}, fmt.Errorf("coinbase failed to get ticker price for %s", gp)
-}
-
-func (p *CoinbaseProvider) messageReceived(messageType int, bz []byte) {
-	var (
-		tickerMsg  CoinbaseWsTickerMsg
-		tickerErr  error
-		matchMsg   CoinbaseWsMatchMsg
-		matchErr   error
-		genericMsg CoinbaseWsGenericMsg
-		genericErr error
-	)
-
-	matchErr = json.Unmarshal(bz, &matchMsg)
-	if matchErr == nil && (matchMsg.Type == "match" || matchMsg.Type == "last_match") {
-		p.updateTicker(matchMsg)
-		telemetryWebsocketMessage(ProviderBinance, MessageTypeTrade)
-		return
-	}
-
-	tickerErr = json.Unmarshal(bz, &tickerMsg)
-	if tickerErr == nil && tickerMsg.Type == "ticker" {
-		p.setTickerPair(tickerMsg)
-		telemetryWebsocketMessage(ProviderBinance, MessageTypeTicker)
-		return
-	}
-
-	genericErr = json.Unmarshal(bz, &genericMsg)
-	if genericErr == nil && genericMsg.Type == "subscription" {
-		return
-	}
-
-	p.logger.Error().
-		Int("length", len(bz)).
-		AnErr("ticker", tickerErr).
-		AnErr("match", matchErr).
-		AnErr("generic", genericErr).
-		Str("msg", string(bz)).
-		Msg("Error on receive message")
-}
-
-func (p *CoinbaseProvider) setTickerPair(ticker CoinbaseWsTickerMsg) {
-	p.mtx.Lock()
-	defer p.mtx.Unlock()
-
-	p.tickers[ticker.ProductID] = ticker
-}
-
-func (p *CoinbaseProvider) updateTicker(matchMsg CoinbaseWsMatchMsg) {
-	p.mtx.Lock()
-	defer p.mtx.Unlock()
-
-	ticker, ok := p.tickers[matchMsg.ProductID]
-	if ok {
-		ticker.Price = matchMsg.Price
-		ticker.Time = matchMsg.Time
-		p.tickers[matchMsg.ProductID] = ticker
-	}
-
+	fmt.Println(ticker)
+	return ticker, nil
 }
 
 // GetAvailablePairs returns all pairs to which the provider can subscribe.
 func (p *CoinbaseProvider) GetAvailablePairs() (map[string]struct{}, error) {
-	resp, err := http.Get(p.endpoints.Rest + coinbaseRestPath)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var pairsSummary []CoinbasePairSummary
-	if err := json.NewDecoder(resp.Body).Decode(&pairsSummary); err != nil {
-		return nil, err
-	}
-
-	availablePairs := make(map[string]struct{}, len(pairsSummary))
-	for _, pair := range pairsSummary {
-		cp := types.CurrencyPair{
-			Base:  strings.ToUpper(pair.Base),
-			Quote: strings.ToUpper(pair.Quote),
-		}
-		availablePairs[cp.String()] = struct{}{}
-	}
-
-	return availablePairs, nil
-}
-
-func (ticker CoinbaseWsTickerMsg) toTickerPrice() (types.TickerPrice, error) {
-	timestamp, err := time.Parse(CoinbaseTimeFormat, ticker.Time)
-	if err != nil {
-		fmt.Println(err)
-	}
-
-	return types.NewTickerPrice(
-		string(ProviderCoinbase),
-		strings.ReplaceAll(ticker.ProductID, "-", ""), // BTC-USDT -> BTCUSDT
-		ticker.Price,
-		ticker.Volume,
-		timestamp.UnixMilli(),
-	)
+	// not used yet, so skipping this unless needed
+	return make(map[string]struct{}, 0), nil
 }

--- a/oracle/provider/coinbase_test.go
+++ b/oracle/provider/coinbase_test.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"price-feeder/oracle/types"
@@ -17,74 +16,80 @@ func TestCoinbaseProvider_GetTickerPrices(t *testing.T) {
 		context.TODO(),
 		zerolog.Nop(),
 		Endpoint{},
-		types.CurrencyPair{Base: "BTC", Quote: "USDT"},
+		testAtomUsdtCurrencyPair,
 	)
 	require.NoError(t, err)
 
 	t.Run("valid_request_single_ticker", func(t *testing.T) {
-		lastPrice := "34.69000000"
-		volume := "2396974.02000000"
-
-		tickerMap := map[string]CoinbaseWsTickerMsg{}
-		tickerMap["ATOM-USDT"] = CoinbaseWsTickerMsg{
-			Price:  lastPrice,
-			Volume: volume,
+		tickers := map[string]types.TickerPrice{}
+		tickers["ATOMUSDT"] = types.TickerPrice{
+			Price:  testAtomPriceDec,
+			Volume: testAtomVolumeDec,
 		}
 
-		p.tickers = tickerMap
+		p.tickers = tickers
 
-		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+		prices, err := p.GetTickerPrices(testAtomUsdtCurrencyPair)
 		require.NoError(t, err)
 		require.Len(t, prices, 1)
-		require.Equal(t, sdk.MustNewDecFromStr(lastPrice), prices["ATOMUSDT"].Price)
-		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["ATOMUSDT"].Volume)
+		require.Equal(
+			t,
+			sdk.MustNewDecFromStr(testAtomPriceString),
+			prices["ATOMUSDT"].Price,
+		)
+		require.Equal(
+			t,
+			sdk.MustNewDecFromStr(testAtomVolumeString),
+			prices["ATOMUSDT"].Volume,
+		)
 	})
 
 	t.Run("valid_request_multi_ticker", func(t *testing.T) {
-		lastPriceAtom := "34.69000000"
-		lastPriceUmee := "41.35000000"
-		volume := "2396974.02000000"
-
-		tickerMap := map[string]CoinbaseWsTickerMsg{}
-		tickerMap["ATOM-USDT"] = CoinbaseWsTickerMsg{
-			Price:  lastPriceAtom,
-			Volume: volume,
+		tickers := map[string]types.TickerPrice{}
+		tickers["ATOMUSDT"] = types.TickerPrice{
+			Price:  testAtomPriceDec,
+			Volume: testAtomVolumeDec,
 		}
 
-		tickerMap["UMEE-USDT"] = CoinbaseWsTickerMsg{
-			Price:  lastPriceUmee,
-			Volume: volume,
+		tickers["BTCUSDT"] = types.TickerPrice{
+			Price:  testBtcPriceDec,
+			Volume: testBtcVolumeDec,
 		}
 
-		p.tickers = tickerMap
+		p.tickers = tickers
+
 		prices, err := p.GetTickerPrices(
-			types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
-			types.CurrencyPair{Base: "UMEE", Quote: "USDT"},
+			testAtomUsdtCurrencyPair,
+			testBtcUsdtCurrencyPair,
 		)
+
 		require.NoError(t, err)
 		require.Len(t, prices, 2)
-		require.Equal(t, sdk.MustNewDecFromStr(lastPriceAtom), prices["ATOMUSDT"].Price)
-		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["ATOMUSDT"].Volume)
-		require.Equal(t, sdk.MustNewDecFromStr(lastPriceUmee), prices["UMEEUSDT"].Price)
-		require.Equal(t, sdk.MustNewDecFromStr(volume), prices["UMEEUSDT"].Volume)
+		require.Equal(
+			t,
+			testBtcPriceDec,
+			prices["BTCUSDT"].Price,
+		)
+		require.Equal(
+			t,
+			testBtcVolumeDec,
+			prices["BTCUSDT"].Volume,
+		)
+		require.Equal(
+			t,
+			testAtomPriceDec,
+			prices["ATOMUSDT"].Price,
+		)
+		require.Equal(
+			t,
+			testAtomVolumeDec,
+			prices["ATOMUSDT"].Volume,
+		)
 	})
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {
 		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "FOO", Quote: "BAR"})
-		require.EqualError(t, err, "coinbase failed to get ticker price for FOO-BAR")
+		require.EqualError(t, err, "coinbase failed to get ticker price for FOOBAR")
 		require.Nil(t, prices)
 	})
-}
-
-func TestCoinbaseProvider_GetSubscriptionMsgs(t *testing.T) {
-	provider := &CoinbaseProvider{
-		subscribedPairs: map[string]types.CurrencyPair{},
-	}
-	cps := []types.CurrencyPair{
-		{Base: "ATOM", Quote: "USDT"},
-	}
-	subMsgs := provider.GetSubscriptionMsgs(cps...)
-
-	msg, _ := json.Marshal(subMsgs[0])
-	require.Equal(t, "{\"type\":\"subscribe\",\"product_ids\":[\"ATOM-USDT\"],\"channels\":[\"matches\",\"ticker\"]}", string(msg))
 }

--- a/oracle/provider/crypto_test.go
+++ b/oracle/provider/crypto_test.go
@@ -16,56 +16,75 @@ func TestCryptoProvider_GetTickerPrices(t *testing.T) {
 		context.TODO(),
 		zerolog.Nop(),
 		Endpoint{},
-		types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
+		testAtomUsdtCurrencyPair,
 	)
 	require.NoError(t, err)
 
 	t.Run("valid_request_single_ticker", func(t *testing.T) {
-		lastPrice := sdk.MustNewDecFromStr("34.69000000")
-		volume := sdk.MustNewDecFromStr("2396974.02000000")
-
-		tickerMap := map[string]types.TickerPrice{}
-		tickerMap["ATOM_USDT"] = types.TickerPrice{
-			Price:  lastPrice,
-			Volume: volume,
+		tickers := map[string]CryptoTicker{}
+		tickers["ATOM_USDT"] = CryptoTicker{
+			Price:  testAtomPriceString,
+			Volume: testAtomVolumeString,
 		}
 
-		p.tickers = tickerMap
+		p.tickers = tickers
 
-		prices, err := p.GetTickerPrices(types.CurrencyPair{Base: "ATOM", Quote: "USDT"})
+		prices, err := p.GetTickerPrices(testAtomUsdtCurrencyPair)
 		require.NoError(t, err)
 		require.Len(t, prices, 1)
-		require.Equal(t, lastPrice, prices["ATOMUSDT"].Price)
-		require.Equal(t, volume, prices["ATOMUSDT"].Volume)
+		require.Equal(
+			t,
+			sdk.MustNewDecFromStr(testAtomPriceString),
+			prices["ATOMUSDT"].Price,
+		)
+		require.Equal(
+			t,
+			sdk.MustNewDecFromStr(testAtomVolumeString),
+			prices["ATOMUSDT"].Volume,
+		)
 	})
 
 	t.Run("valid_request_multi_ticker", func(t *testing.T) {
-		lastPriceAtom := sdk.MustNewDecFromStr("34.69000000")
-		lastPriceLuna := sdk.MustNewDecFromStr("41.35000000")
-		volume := sdk.MustNewDecFromStr("2396974.02000000")
-
-		tickerMap := map[string]types.TickerPrice{}
-		tickerMap["ATOM_USDT"] = types.TickerPrice{
-			Price:  lastPriceAtom,
-			Volume: volume,
+		tickers := map[string]CryptoTicker{}
+		tickers["ATOM_USDT"] = CryptoTicker{
+			Price:  testAtomPriceString,
+			Volume: testAtomVolumeString,
 		}
 
-		tickerMap["LUNA_USDT"] = types.TickerPrice{
-			Price:  lastPriceLuna,
-			Volume: volume,
+		tickers["BTC_USDT"] = CryptoTicker{
+			Price:  testBtcPriceString,
+			Volume: testBtcVolumeString,
 		}
 
-		p.tickers = tickerMap
+		p.tickers = tickers
+
 		prices, err := p.GetTickerPrices(
-			types.CurrencyPair{Base: "ATOM", Quote: "USDT"},
-			types.CurrencyPair{Base: "LUNA", Quote: "USDT"},
+			testAtomUsdtCurrencyPair,
+			testBtcUsdtCurrencyPair,
 		)
+
 		require.NoError(t, err)
 		require.Len(t, prices, 2)
-		require.Equal(t, lastPriceAtom, prices["ATOMUSDT"].Price)
-		require.Equal(t, volume, prices["ATOMUSDT"].Volume)
-		require.Equal(t, lastPriceLuna, prices["LUNAUSDT"].Price)
-		require.Equal(t, volume, prices["LUNAUSDT"].Volume)
+		require.Equal(
+			t,
+			testBtcPriceDec,
+			prices["BTCUSDT"].Price,
+		)
+		require.Equal(
+			t,
+			testBtcVolumeDec,
+			prices["BTCUSDT"].Volume,
+		)
+		require.Equal(
+			t,
+			testAtomPriceDec,
+			prices["ATOMUSDT"].Price,
+		)
+		require.Equal(
+			t,
+			testAtomVolumeDec,
+			prices["ATOMUSDT"].Volume,
+		)
 	})
 
 	t.Run("invalid_request_invalid_ticker", func(t *testing.T) {
@@ -74,10 +93,4 @@ func TestCryptoProvider_GetTickerPrices(t *testing.T) {
 		require.Equal(t, "crypto failed to get ticker price for FOO_BAR", err.Error())
 		require.Nil(t, prices)
 	})
-}
-
-func TestCryptoCurrencyPairToCryptoPair(t *testing.T) {
-	cp := types.CurrencyPair{Base: "ATOM", Quote: "USDT"}
-	cryptoSymbol := cp.Join("_")
-	require.Equal(t, cryptoSymbol, "ATOM_USDT")
 }

--- a/oracle/provider/kucoin_test.go
+++ b/oracle/provider/kucoin_test.go
@@ -22,8 +22,8 @@ func TestKucoinProvider_GetTickerPrices(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("valid_request_single_ticker", func(t *testing.T) {
-		tickers := map[string]KucoinSnapshotDataData{}
-		tickers["ATOMUSDT"] = KucoinSnapshotDataData{
+		tickers := map[string]KucoinWsSnapshotDataData{}
+		tickers["ATOMUSDT"] = KucoinWsSnapshotDataData{
 			Price:  testAtomPriceFloat64,
 			Volume: testAtomVolumeFloat64,
 		}
@@ -47,12 +47,12 @@ func TestKucoinProvider_GetTickerPrices(t *testing.T) {
 	})
 
 	t.Run("valid_request_multi_ticker", func(t *testing.T) {
-		tickers := map[string]KucoinSnapshotDataData{}
-		tickers["ATOMUSDT"] = KucoinSnapshotDataData{
+		tickers := map[string]KucoinWsSnapshotDataData{}
+		tickers["ATOMUSDT"] = KucoinWsSnapshotDataData{
 			Price:  testAtomPriceFloat64,
 			Volume: testAtomVolumeFloat64,
 		}
-		tickers["BTCUSDT"] = KucoinSnapshotDataData{
+		tickers["BTCUSDT"] = KucoinWsSnapshotDataData{
 			Price:  testBtcPriceFloat64,
 			Volume: testBtcVolumeFloat64,
 		}

--- a/oracle/provider/okx.go
+++ b/oracle/provider/okx.go
@@ -189,7 +189,7 @@ func (p *OkxProvider) GetTickerPrices(cps ...types.CurrencyPair) (map[string]typ
 		}
 
 		query := req.URL.Query()
-		query.Add("instType", "SWAP")
+		query.Add("instType", "SPOT")
 		req.URL.RawQuery = query.Encode()
 
 		resp, err := client.Do(req)

--- a/oracle/provider/request_controller.go
+++ b/oracle/provider/request_controller.go
@@ -1,0 +1,54 @@
+package provider
+
+import (
+	"context"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+type (
+	RequestHandler           func() error
+	GenericRequestController struct {
+		parentCtx       context.Context
+		requestInterval time.Duration
+		requestHandler  RequestHandler
+		logger          zerolog.Logger
+	}
+)
+
+func NewGenericRequestController(
+	ctx context.Context,
+	requestInterval time.Duration,
+	requestHandler RequestHandler,
+	logger zerolog.Logger,
+) *GenericRequestController {
+	return &GenericRequestController{
+		parentCtx:       ctx,
+		requestInterval: requestInterval,
+		requestHandler:  requestHandler,
+		logger:          logger,
+	}
+}
+
+func (grc *GenericRequestController) Start() {
+	go grc.requestLoop()
+}
+
+func (grc *GenericRequestController) requestLoop() {
+	requestTicker := time.NewTicker(grc.requestInterval)
+
+	for {
+		grc.logger.Debug().Msg("process request handler")
+		err := grc.requestHandler()
+		if err != nil {
+			continue
+		}
+		select {
+		case <-grc.parentCtx.Done():
+			return
+		case <-requestTicker.C:
+			continue
+		}
+	}
+}


### PR DESCRIPTION
Switch to using websocket trade or candle subscriptions for more accurate price- and rest api for volume reporting on most CEX providers. That removes most outliers in reported prices that occurred when using websocket tickers only. 

Add a new generic loop controller, that can instantiated by providing a handler function that gets executed in parallel on a configurable interval. That allows periodical polling of prices from a rest api, which otherwise might take to long to do on every call to GetPrices(). 