### PR TITLE
report endpoint.Name for url errors during validation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -242,7 +242,7 @@ func endpointValidation(sl validator.StructLevel) {
 	}
 
 	if len(endpoint.Urls) < 1 && len(endpoint.UrlSet) < 1 {
-		sl.ReportError(endpoint, "urls", "Urls", "urls or url_set empty", "")
+		sl.ReportError(endpoint.Name, "urls", "Urls", "urls or url_set empty", "")
 	}
 
 	if _, ok := SupportedProviders[endpoint.Name]; !ok {


### PR DESCRIPTION
Interstellar validator here - this is probably a typo but the url validation error should report the endpoint name